### PR TITLE
No longer need to add a loader for cmd line args

### DIFF
--- a/andhow-usage-examples/src/main/java/howto/force/config/sample/printing/ReallySimpleApp.java
+++ b/andhow-usage-examples/src/main/java/howto/force/config/sample/printing/ReallySimpleApp.java
@@ -14,10 +14,9 @@ public class ReallySimpleApp {
 	
 	public static void main(String[] args) {
 		AndHow.builder()
-				.cmdLineArgs(args)
-				.loader(new StringArgumentLoader())	/* Used to read cmdLine args */
+				.cmdLineArgs(args) /* Implicitly adds a loader for these cmd line args */
 				.loader(new PropertyFileOnClasspathLoader(MySetOfProps.CLASSPATH_PROP))
-				.group(MySetOfProps.class) /* 2) MySetOfProps defined below */
+				.group(MySetOfProps.class) /* MySetOfProps defined below */
 				.build();
 	
 		System.out.println("Examples of using the configured properties (they initially have default values)");

--- a/andhow/src/main/java/org/yarnandtail/andhow/Loader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/Loader.java
@@ -7,10 +7,14 @@ import java.util.List;
  * source.
  *
  * Implementations may define a set of Properties used to control the behavior
- * of the loader, which are returned from getClassConfig(). During AndHow
- * startup, these parameters will are automatically added to the list of
+ * of all instances of a loader, which are returned from getClassConfig().
+ * During AndHow startup, these parameters will be automatically added to the list of
  * registered Properties. Values for these properties need to be loaded by a
  * preceding loader or <em>forced</em> in the AndHowBuilder.
+ * 
+ * Implementations may also define instance level configuration by returning
+ * a list of Properties from getInstanceConfig().  These properties must have been
+ * added to the groups added to the AndHow builder via addGroup().
  *
  * Instances should not hold state because they are held in memory for the life
  * of the application.
@@ -24,11 +28,10 @@ public interface Loader {
 	 * source.
 	 * 
 	 * @param runtimeDef
-	 * @param cmdLineArgs All loaders receive the command line args even though they only apply to the cmd line loader
 	 * @param existingValues
 	 * @return 
 	 */
-	LoaderValues load(ConstructionDefinition runtimeDef, List<String> cmdLineArgs,
+	LoaderValues load(ConstructionDefinition runtimeDef,
 			ValueMapWithContext existingValues);
 	
 	/**

--- a/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
@@ -17,7 +17,6 @@ import org.yarnandtail.andhow.util.ReportGenerator;
 public class AndHowCore implements ConstructionDefinition, ValueMap {
 	//User config
 	private final List<Loader> loaders = new ArrayList();
-	private final List<String> cmdLineArgs = new ArrayList();
 	
 	//Internal state
 	private final ConstructionDefinition runtimeDef;
@@ -25,8 +24,8 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 	private final ProblemList<Problem> problems = new ProblemList();
 	
 	public AndHowCore(NamingStrategy naming, List<Loader> loaders, 
-			List<Class<? extends PropertyGroup>> registeredGroups, 
-			String[] cmdLineArgs) throws AppFatalException {
+			List<Class<? extends PropertyGroup>> registeredGroups) 
+			throws AppFatalException {
 		
 		NamingStrategy namingStrategy = (naming != null)?naming:new CaseInsensitiveNaming();
 		
@@ -38,11 +37,7 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 					problems.add(new ConstructionProblem.DuplicateLoader(loader));
 				}
 			}
-		}
-		
-		if (cmdLineArgs != null && cmdLineArgs.length > 0) {
-			this.cmdLineArgs.addAll(Arrays.asList(cmdLineArgs));
-		}
+		}		
 		
 		//The global options are always added to the list of registered groups
 		ArrayList<Class<? extends PropertyGroup>> effRegGroups = new ArrayList();
@@ -119,13 +114,12 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 		return loadedValues.getEffectiveValue(prop);
 	}
 	
-	//TODO:  Snhouldn't this be stateless and pass in the loaer list?
+	//TODO:  Shouldn't this be stateless and pass in the loader list?
 	private ValueMapWithContext loadValues(ConstructionDefinition definition, ProblemList<Problem> problems) {
 		ValueMapWithContextMutable existingValues = new ValueMapWithContextMutable();
 
-		//LoaderState state = new LoaderState(cmdLineArgs, existingValues, runtimeDef);
 		for (Loader loader : loaders) {
-			LoaderValues result = loader.load(definition, cmdLineArgs, existingValues);
+			LoaderValues result = loader.load(definition, existingValues);
 			existingValues.addValues(result);
 			problems.addAll(result.getProblems());
 		}

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/EnviromentVariableLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/EnviromentVariableLoader.java
@@ -32,8 +32,7 @@ public class EnviromentVariableLoader extends BaseLoader {
 	}
 	
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 		
 		ArrayList<PropertyValue> values = new ArrayList();
 		ProblemList<Problem> problems = new ProblemList();

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/FixedValueLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/FixedValueLoader.java
@@ -28,8 +28,7 @@ public class FixedValueLoader extends BaseLoader {
 	}
 	
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 		return new LoaderValues(this, values, ProblemList.EMPTY_PROBLEM_LIST);
 	}
 	

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/JndiLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/JndiLoader.java
@@ -29,8 +29,7 @@ public class JndiLoader extends BaseLoader {
 	static String JNDI_PROTOCOL_NAME = "java:";
 
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 
 		ArrayList<String> jndiRoots = buildJndiRoots(existingValues);
 

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoader.java
@@ -56,8 +56,7 @@ public class PropertyFileOnClasspathLoader extends PropertyFileBaseLoader {
 	
 
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 
 		String path = existingValues.getEffectiveValue(classpath);
 		specificLoadDescription = "file on classpath at: " + path;

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoader.java
@@ -56,8 +56,7 @@ public class PropertyFileOnFilesystemLoader extends PropertyFileBaseLoader {
 	
 
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 
 		String path = existingValues.getEffectiveValue(filepath);
 		specificLoadDescription = TextUtil.format("file on the file system at path : {} ({})",

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/StringArgumentLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/StringArgumentLoader.java
@@ -1,6 +1,8 @@
 package org.yarnandtail.andhow.load;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.internal.LoaderProblem;
@@ -29,12 +31,43 @@ import org.yarnandtail.andhow.internal.LoaderProblem;
  */
 public class StringArgumentLoader extends BaseLoader {
 	
-	public StringArgumentLoader() {
+	private final List<String> cmdLineArgs;
+	
+	/**
+	 * Construct using a list of Strings, each string containing a key-value pair.
+	 * 
+	 * KVPs are split by KVP.splitKVP using '=' as the delimiter, as defined in
+	 * AndHow.KVP_DELIMITER.
+	 * 
+	 * @param inCmdLineArgs 
+	 */
+	public StringArgumentLoader(List<String> inCmdLineArgs) {
+		if (inCmdLineArgs != null && inCmdLineArgs.size() > 0) {
+			cmdLineArgs = new ArrayList();
+			cmdLineArgs.addAll(inCmdLineArgs);
+		} else {
+			cmdLineArgs = Collections.emptyList();
+		}
+	}
+	
+	/**
+	 * Construct using an array of Strings, each string containing a key-value pair.
+	 * 
+	 * KVPs are split by KVP.splitKVP using '=' as the delimiter, as defined in
+	 * AndHow.KVP_DELIMITER.
+	 * 
+	 * @param inCmdLineArgs 
+	 */
+	public StringArgumentLoader(String[] inCmdLineArgs) {
+		if (inCmdLineArgs != null && inCmdLineArgs.length > 0) {
+			cmdLineArgs = Arrays.asList(inCmdLineArgs);
+		} else {
+			cmdLineArgs = Collections.emptyList();
+		}
 	}
 	
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 		
 		ArrayList<PropertyValue> values = new ArrayList();
 		ProblemList<Problem> problems = new ProblemList();

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/SystemPropertyLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/SystemPropertyLoader.java
@@ -31,8 +31,7 @@ public class SystemPropertyLoader extends BaseLoader {
 	}
 	
 	@Override
-	public LoaderValues load(ConstructionDefinition appConfigDef, List<String> cmdLineArgs,
-			ValueMapWithContext existingValues) {
+	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 		
 		ArrayList<PropertyValue> values = new ArrayList();
 		ProblemList<Problem> problems = new ProblemList();

--- a/andhow/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -1,16 +1,14 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.internal.RequirementProblem;
-import org.yarnandtail.andhow.internal.ConstructionProblem;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-
 import static org.junit.Assert.*;
-
 import org.junit.Before;
+import org.junit.Test;
+import org.yarnandtail.andhow.internal.ConstructionProblem;
+import org.yarnandtail.andhow.internal.RequirementProblem;
 import org.yarnandtail.andhow.load.StringArgumentLoader;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.FlagProp;
@@ -24,7 +22,6 @@ public class AndHowTest extends AndHowTestBase {
 	
 	String paramFullPath = SimpleParams.class.getCanonicalName() + ".";
 	CaseInsensitiveNaming basicNaming = new CaseInsensitiveNaming();
-	List<Loader> loaders = new ArrayList();
 	ArrayList<Class<? extends PropertyGroup>> configPtGroups = new ArrayList();
 	Map<Property<?>, Object> startVals = new HashMap();
 	String[] cmdLineArgsWFullClassName = new String[0];
@@ -39,9 +36,6 @@ public class AndHowTest extends AndHowTestBase {
 	
 	@Before
 	public void setup() {
-		
-		loaders.clear();
-		loaders.add(new StringArgumentLoader());
 		
 		configPtGroups.clear();
 		configPtGroups.add(SimpleParams.class);
@@ -74,7 +68,6 @@ public class AndHowTest extends AndHowTestBase {
 	public void testCmdLineLoaderUsingClassBaseName() {
 		AndHow.builder()
 				.namingStrategy(basicNaming)
-				.loaders(loaders)
 				.groups(configPtGroups)
 				.cmdLineArgs(cmdLineArgsWFullClassName)
 				.reloadForNonPropduction(reloader);
@@ -88,6 +81,9 @@ public class AndHowTest extends AndHowTestBase {
 	
 	@Test
 	public void testBlowingUpWithDuplicateLoaders() {
+		
+		List<Loader> loaders = new ArrayList();
+		loaders.add(new StringArgumentLoader(cmdLineArgsWFullClassName));
 		
 		try {
 
@@ -113,7 +109,6 @@ public class AndHowTest extends AndHowTestBase {
 		try {
 				AndHow.builder()
 					.namingStrategy(basicNaming)
-					.loaders(loaders)
 					.groups(configPtGroups)
 					.group(RequiredParams.class)
 					.cmdLineArgs(cmdLineArgsWFullClassName)

--- a/andhow/src/test/java/org/yarnandtail/andhow/AndHowTestBase.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/AndHowTestBase.java
@@ -1,10 +1,9 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.AndHow;
-import javax.naming.NamingException;
 import java.util.logging.*;
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+import javax.naming.NamingException;
 import org.junit.BeforeClass;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 
 /**
  * All tests using AppConfig must extend this class so they have access to the

--- a/andhow/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -1,14 +1,9 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.AndHow;
-import org.yarnandtail.andhow.PropertyGroup;
-import org.yarnandtail.andhow.AppFatalException;
-import org.yarnandtail.andhow.internal.RequirementProblem;
-
 import static org.junit.Assert.*;
-
 import org.junit.Before;
 import org.junit.Test;
+import org.yarnandtail.andhow.internal.RequirementProblem;
 import org.yarnandtail.andhow.load.StringArgumentLoader;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
@@ -41,7 +36,6 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 	public void testAllValuesAreSet() {
 		AndHow.builder()
 				.group(UI_CONFIG.class).group(SERVICE_CONFIG.class)
-				.loader(new StringArgumentLoader())
 				.cmdLineArgs(cmdLineArgsWFullClassName)
 				.reloadForNonPropduction(reloader);
 		
@@ -56,7 +50,6 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 	public void testOptionalValuesAreUnset() {
 		AndHow.builder()
 				.group(UI_CONFIG.class).group(SERVICE_CONFIG.class)
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(uiFullPath + "DISPLAY_NAME", "My App")
 				.cmdLineArg(svsFullPath + "REST_ENDPOINT_URL", "yahoo.com")
 				.cmdLineArg(svsFullPath + "TIMEOUT_SECONDS", "99")
@@ -75,7 +68,6 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 		try {
 			AndHow.builder()
 					.group(UI_CONFIG.class).group(SERVICE_CONFIG.class)
-					.loader(new StringArgumentLoader())
 					.reloadForNonPropduction(reloader);
 			fail();
 		} catch (AppFatalException ce) {

--- a/andhow/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
@@ -1,23 +1,16 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.AndHow;
-import org.yarnandtail.andhow.AppFatalException;
-import org.yarnandtail.andhow.PropertyGroup;
-import org.yarnandtail.andhow.internal.ConstructionProblem;
 import java.util.List;
-
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import static org.yarnandtail.andhow.AndHowTestBase.reloader;
-
+import org.yarnandtail.andhow.internal.ConstructionProblem;
+import org.yarnandtail.andhow.load.JndiLoader;
 import org.yarnandtail.andhow.load.StringArgumentLoader;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
-import org.yarnandtail.andhow.load.JndiLoader;
 
 /**
  *
@@ -75,7 +68,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 	@Test
 	public void testFirstSetOfInAliasesViaCmdLine() {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(STR_PROP1_IN, STR1)
 				.cmdLineArg(STR_PROP2_ALIAS, STR2)
 				.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())
@@ -91,7 +83,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 	@Test
 	public void testSecondSetOfInAliasesViaCmdLine() {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(STR_PROP1_IN_AND_OUT_ALIAS, STR1)
 				.cmdLineArg(STR_PROP2_IN_ALT1_ALIAS, STR2)
 				.cmdLineArg(INT_PROP1_ALT_IN1_ALIAS, INT1.toString())
@@ -106,7 +97,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 	@Test
 	public void testThirdSetOfInAliasesViaCmdLine() {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(STR_PROP1_IN_AND_OUT_ALIAS, STR1)
 				.cmdLineArg(STR_PROP2_IN_ALT2_ALIAS, STR2)
 				.cmdLineArg(INT_PROP1_ALT_IN1_ALIAS, INT1.toString())
@@ -218,7 +208,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.cmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
 					.cmdLineArg(STR_PROP2_ALIAS, STR2)
 					.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())
@@ -245,7 +234,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.cmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
 					.cmdLineArg(STR_PROP2_ALIAS, STR2)
 					.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())
@@ -271,7 +259,6 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.cmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
 					.cmdLineArg(STR_PROP2_ALIAS, STR2)
 					.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())

--- a/andhow/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
@@ -1,30 +1,19 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.AndHow;
-import org.yarnandtail.andhow.AppFatalException;
-import org.yarnandtail.andhow.PropertyGroup;
-import org.yarnandtail.andhow.Exporter;
-import org.yarnandtail.andhow.Name;
-import org.yarnandtail.andhow.GroupExport;
-import org.yarnandtail.andhow.internal.ConstructionProblem;
 import java.util.List;
-
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 import static org.yarnandtail.andhow.AndHowTestBase.reloader;
-
+import org.yarnandtail.andhow.PropertyGroup.NameAndProperty;
+import org.yarnandtail.andhow.export.SysPropExporter;
+import org.yarnandtail.andhow.internal.ConstructionProblem;
 import org.yarnandtail.andhow.load.StringArgumentLoader;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
-import org.junit.Before;
-import org.junit.After;
-import org.junit.AfterClass;
-
-import org.yarnandtail.andhow.PropertyGroup.NameAndProperty;
-import org.yarnandtail.andhow.export.SysPropExporter;
 
 /**
  *
@@ -104,7 +93,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 	@Test
 	public void testOutAliasForGroup1() {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(STR_PROP1_IN, STR1)
 				.cmdLineArg(STR_PROP2_IN_ALIAS, STR2)
 				.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())
@@ -146,7 +134,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		String grp2Name = AliasGroup2.class.getCanonicalName();
 		
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.cmdLineArg(grp2Name + ".strProp1", STR1)
 				.cmdLineArg(grp2Name + ".strProp2", STR2)
 				.cmdLineArg(grp2Name + ".intProp1", INT1.toString())
@@ -169,7 +156,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		String grp2Name = AliasGroup2.class.getCanonicalName();
 		
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.group(AliasGroup1.class)
 				.group(AliasGroup2.class)
 				.cmdLineArg(STR_PROP1_IN, STR1)
@@ -217,7 +203,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.cmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
 					.cmdLineArg(STR_PROP2_IN_ALIAS, STR2)
 					.cmdLineArg(INT_PROP1_ALIAS, INT1.toString())
@@ -244,7 +229,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.group(AliasGroup5.class)
 					.reloadForNonPropduction(reloader);
 			
@@ -267,7 +251,6 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
 					.group(AliasGroup6.class)
 					.group(AliasGroup7.class)
 					.reloadForNonPropduction(reloader);

--- a/andhow/src/test/java/org/yarnandtail/andhow/ConstructionDefinitionImmutableTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/ConstructionDefinitionImmutableTest.java
@@ -1,16 +1,10 @@
 package org.yarnandtail.andhow;
 
 
-import org.yarnandtail.andhow.ConstructionDefinition;
-import org.yarnandtail.andhow.ProblemList;
-import org.yarnandtail.andhow.PropertyGroup;
-import org.yarnandtail.andhow.NamingStrategy;
-import org.yarnandtail.andhow.internal.ConstructionProblem;
-
 import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.yarnandtail.andhow.internal.ConstructionDefinitionMutable;
+import org.yarnandtail.andhow.internal.ConstructionProblem;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.StrProp;
 

--- a/andhow/src/test/java/org/yarnandtail/andhow/ConstructionDefinitionMutableTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/ConstructionDefinitionMutableTest.java
@@ -1,15 +1,10 @@
 package org.yarnandtail.andhow;
 
 
-import org.yarnandtail.andhow.ProblemList;
-import org.yarnandtail.andhow.PropertyGroup;
-import org.yarnandtail.andhow.NamingStrategy;
-import org.yarnandtail.andhow.internal.ConstructionProblem;
-
 import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.yarnandtail.andhow.internal.ConstructionDefinitionMutable;
+import org.yarnandtail.andhow.internal.ConstructionProblem;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.StrProp;
 

--- a/andhow/src/test/java/org/yarnandtail/andhow/NamingStrategyTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/NamingStrategyTest.java
@@ -1,9 +1,8 @@
 package org.yarnandtail.andhow;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
-
-import static org.junit.Assert.*;
 
 /**
  *

--- a/andhow/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -1,12 +1,11 @@
 package org.yarnandtail.andhow;
 
-import org.yarnandtail.andhow.property.LocalDateTimeProp;
-import org.yarnandtail.andhow.property.IntProp;
-import org.yarnandtail.andhow.property.StrProp;
-import org.yarnandtail.andhow.property.FlagProp;
-import org.yarnandtail.andhow.property.LngProp;
-import org.yarnandtail.andhow.PropertyGroup;
 import java.time.LocalDateTime;
+import org.yarnandtail.andhow.property.FlagProp;
+import org.yarnandtail.andhow.property.IntProp;
+import org.yarnandtail.andhow.property.LngProp;
+import org.yarnandtail.andhow.property.LocalDateTimeProp;
+import org.yarnandtail.andhow.property.StrProp;
 
 /**
  * Test set of params w/ one of each type.

--- a/andhow/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
@@ -45,9 +45,8 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 				
 		AndHow.builder()
 				.group(SampleRestClientGroup.class)
-				.loader(new StringArgumentLoader())
-				.loader(new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE))
 				.cmdLineArgs(cmdLineArgs)
+				.loader(new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE))
 				.reloadForNonPropduction(reloader);
 		
 		assertEquals("/org/yarnandtail/andhow/example/restclient/all.points.speced.properties", 
@@ -74,9 +73,8 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 				
 		AndHow.builder()
 				.group(SampleRestClientGroup.class)
-				.loader(new StringArgumentLoader())
-				.loader(new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE))
 				.cmdLineArgs(cmdLineArgs)
+				.loader(new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE))
 				.reloadForNonPropduction(reloader);
 		
 		assertEquals("/org/yarnandtail/andhow/example/restclient/minimum.points.speced.properties", 
@@ -108,10 +106,9 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 			//Error expected b/c some values are invalid
 			AndHow.builder()
 					.group(SampleRestClientGroup.class)
-					.loader(new StringArgumentLoader())
+					.cmdLineArgs(cmdLineArgs)
 					.loader(new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE))
 					.loader(new JndiLoader())
-					.cmdLineArgs(cmdLineArgs)
 					.reloadForNonPropduction(reloader);
 		} catch (AppFatalException e) {
 			

--- a/andhow/src/test/java/org/yarnandtail/andhow/internal/ValueMapWithContextMutableTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/internal/ValueMapWithContextMutableTest.java
@@ -27,7 +27,7 @@ public class ValueMapWithContextMutableTest {
 		
 		ValueMapWithContextMutable builder = new ValueMapWithContextMutable();
 		
-		Loader cmdLineLoad = new StringArgumentLoader();
+		Loader cmdLineLoad = new StringArgumentLoader(new String[]{});
 		Loader propFileLoad = new PropertyFileOnClasspathLoader(SampleRestClientGroup.CLASSPATH_PROP_FILE);
 		
 		List<PropertyValue> firstSet = new ArrayList();

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/EnviromentVariableLoaderTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/EnviromentVariableLoaderTest.java
@@ -51,7 +51,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -75,7 +75,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -105,7 +105,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -129,7 +129,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -153,7 +153,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -180,7 +180,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -198,7 +198,7 @@ public class EnviromentVariableLoaderTest {
 		
 		EnviromentVariableLoader spl = new EnviromentVariableLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderAppTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderAppTest.java
@@ -24,10 +24,9 @@ public class PropertyFileOnClasspathLoaderAppTest {
 	@Test
 	public void testHappyPath() throws Exception {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
-				.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 				.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.CLAZZ_PATH), 
 						"/org/yarnandtail/andhow/load/SimpleParams1.properties")
+				.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 				.group(SimpleParams.class)
 				.group(TestProps.class)
 				.reloadForNonPropduction(reloader);
@@ -46,10 +45,9 @@ public class PropertyFileOnClasspathLoaderAppTest {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
-					.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 					.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.CLAZZ_PATH), 
 							"/org/yarnandtail/andhow/load/SimpleParams1.properties")
+					.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 					.group(SimpleParams.class)
 					//.group(TestProps.class)	//This must be declared or the Prop loader can't work
 					.reloadForNonPropduction(reloader);
@@ -71,7 +69,6 @@ public class PropertyFileOnClasspathLoaderAppTest {
 	@Test
 	public void testUnspecifiedConfigParam() throws Exception {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 				.group(SimpleParams.class)
 				.group(TestProps.class)
@@ -87,10 +84,9 @@ public class PropertyFileOnClasspathLoaderAppTest {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
-					.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 					.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.CLAZZ_PATH), 
 							"asdfasdfasdf/asdfasdf/asdf")
+					.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
 					.group(SimpleParams.class)
 					.group(TestProps.class)
 					.reloadForNonPropduction(reloader);

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderUnitTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderUnitTest.java
@@ -48,12 +48,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams1.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -71,12 +71,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams2.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -93,12 +93,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams3.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -116,12 +116,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams4.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -139,12 +139,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams5.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -160,12 +160,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/SimpleParams6.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(2, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
@@ -181,12 +181,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(1, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
@@ -206,12 +206,12 @@ public class PropertyFileOnClasspathLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		//evl.add(new PropertyValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnClasspathLoader pfl = new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 	}

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoaderAppTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoaderAppTest.java
@@ -48,10 +48,9 @@ public class PropertyFileOnFilesystemLoaderAppTest {
 	@Test
 	public void testHappyPath() throws Exception {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
-				.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 				.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.FILEPATH), 
 						tempPropertiesFile.getAbsolutePath())
+				.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 				.group(SimpleParams.class)
 				.group(TestProps.class)
 				.reloadForNonPropduction(reloader);
@@ -70,10 +69,9 @@ public class PropertyFileOnFilesystemLoaderAppTest {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
-					.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 					.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.FILEPATH), 
 							tempPropertiesFile.getAbsolutePath())
+					.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 					.group(SimpleParams.class)
 					//.group(TestProps.class)	//This must be declared or the Prop loader can't work
 					.reloadForNonPropduction(reloader);
@@ -95,7 +93,6 @@ public class PropertyFileOnFilesystemLoaderAppTest {
 	@Test
 	public void testUnspecifiedConfigParam() throws Exception {
 		AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-				.loader(new StringArgumentLoader())
 				.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 				.group(SimpleParams.class)
 				.group(TestProps.class)
@@ -111,10 +108,9 @@ public class PropertyFileOnFilesystemLoaderAppTest {
 		
 		try {
 			AndHow.builder().namingStrategy(new CaseInsensitiveNaming())
-					.loader(new StringArgumentLoader())
-					.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 					.cmdLineArg(PropertyGroup.getCanonicalName(TestProps.class, TestProps.FILEPATH), 
 							"asdfasdfasdf/asdfasdf/asdf")
+					.loader(new PropertyFileOnFilesystemLoader(TestProps.FILEPATH))
 					.group(SimpleParams.class)
 					.group(TestProps.class)
 					.reloadForNonPropduction(reloader);

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoaderUnitTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnFilesystemLoaderUnitTest.java
@@ -65,12 +65,12 @@ public class PropertyFileOnFilesystemLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.FILEPATH, tempPropertiesFile.getAbsolutePath()));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnFilesystemLoader pfl = new PropertyFileOnFilesystemLoader(TestProps.FILEPATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -87,12 +87,12 @@ public class PropertyFileOnFilesystemLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		evl.add(new PropertyValue(TestProps.FILEPATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnFilesystemLoader pfl = new PropertyFileOnFilesystemLoader(TestProps.FILEPATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(1, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
@@ -112,12 +112,12 @@ public class PropertyFileOnFilesystemLoaderUnitTest {
 		
 		ArrayList<PropertyValue> evl = new ArrayList();
 		//evl.add(new PropertyValue(TestProps.FILEPATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
-		LoaderValues existing = new LoaderValues(new StringArgumentLoader(), evl, new ProblemList<Problem>());
+		LoaderValues existing = new LoaderValues(new StringArgumentLoader(new String[]{}), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
 		
 		PropertyFileOnFilesystemLoader pfl = new PropertyFileOnFilesystemLoader(TestProps.FILEPATH);
 		
-		LoaderValues result = pfl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = pfl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 	}

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/StringArgumentLoaderTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/StringArgumentLoaderTest.java
@@ -36,7 +36,7 @@ public class StringArgumentLoaderTest {
 	}
 	
 	@Test
-	public void testCmdLineLoaderHappyPath() {
+	public void testCmdLineLoaderHappyPathAsList() {
 		
 		String basePath = SimpleParams.class.getCanonicalName() + ".";
 		
@@ -48,9 +48,35 @@ public class StringArgumentLoaderTest {
 		args.add(basePath + "FLAG_NULL" + AndHow.KVP_DELIMITER + "true");
 		
 		
-		StringArgumentLoader cll = new StringArgumentLoader();
+		StringArgumentLoader cll = new StringArgumentLoader(args);
 		
-		LoaderValues result = cll.load(appDef, args, appValuesBuilder);
+		LoaderValues result = cll.load(appDef, appValuesBuilder);
+		
+		assertEquals(0, result.getProblems().size());
+		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
+		assertEquals("test", result.getExplicitValue(SimpleParams.STR_BOB));
+		assertEquals("not_null", result.getExplicitValue(SimpleParams.STR_NULL));
+		assertEquals(Boolean.FALSE, result.getExplicitValue(SimpleParams.FLAG_TRUE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
+	}
+	
+	@Test
+	public void testCmdLineLoaderHappyPathAsArray() {
+		
+		String basePath = SimpleParams.class.getCanonicalName() + ".";
+		
+		List<String> args = new ArrayList();
+		args.add(basePath + "STR_BOB" + AndHow.KVP_DELIMITER + "test");
+		args.add(basePath + "STR_NULL" + AndHow.KVP_DELIMITER + "not_null");
+		args.add(basePath + "FLAG_TRUE" + AndHow.KVP_DELIMITER + "false");
+		args.add(basePath + "FLAG_FALSE" + AndHow.KVP_DELIMITER + "true");
+		args.add(basePath + "FLAG_NULL" + AndHow.KVP_DELIMITER + "true");
+		
+		
+		StringArgumentLoader cll = new StringArgumentLoader(args.toArray(new String[5]));
+		
+		LoaderValues result = cll.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -74,9 +100,9 @@ public class StringArgumentLoaderTest {
 		args.add(basePath + "FLAG_FALSE" + AndHow.KVP_DELIMITER + "");
 		args.add(basePath + "FLAG_NULL" + AndHow.KVP_DELIMITER + "");
 		
-		StringArgumentLoader cll = new StringArgumentLoader();
+		StringArgumentLoader cll = new StringArgumentLoader(args);
 		
-		LoaderValues result = cll.load(appDef, args, appValuesBuilder);
+		LoaderValues result = cll.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -103,9 +129,9 @@ public class StringArgumentLoaderTest {
 		args.add(basePath + "FLAG_NULL" + AndHow.KVP_DELIMITER + "false");
 		
 		
-		StringArgumentLoader cll = new StringArgumentLoader();
+		StringArgumentLoader cll = new StringArgumentLoader(args);
 		
-		LoaderValues result = cll.load(appDef, args, appValuesBuilder);
+		LoaderValues result = cll.load(appDef, appValuesBuilder);
 		
 		assertEquals(3, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
@@ -126,9 +152,9 @@ public class StringArgumentLoaderTest {
 		args.add(basePath + "YYY" + AndHow.KVP_DELIMITER + "2");
 		
 		
-		StringArgumentLoader cll = new StringArgumentLoader();
+		StringArgumentLoader cll = new StringArgumentLoader(args);
 		
-		LoaderValues result = cll.load(appDef, args, appValuesBuilder);
+		LoaderValues result = cll.load(appDef, appValuesBuilder);
 		
 		assertEquals(2, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/SystemPropertyLoaderTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/SystemPropertyLoaderTest.java
@@ -73,7 +73,7 @@ public class SystemPropertyLoaderTest {
 		
 		SystemPropertyLoader spl = new SystemPropertyLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -103,7 +103,7 @@ public class SystemPropertyLoaderTest {
 		
 		SystemPropertyLoader spl = new SystemPropertyLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -127,7 +127,7 @@ public class SystemPropertyLoaderTest {
 		
 		SystemPropertyLoader spl = new SystemPropertyLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -154,7 +154,7 @@ public class SystemPropertyLoaderTest {
 		
 		SystemPropertyLoader spl = new SystemPropertyLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
@@ -172,7 +172,7 @@ public class SystemPropertyLoaderTest {
 		
 		SystemPropertyLoader spl = new SystemPropertyLoader();
 		
-		LoaderValues result = spl.load(appDef, null, appValuesBuilder);
+		LoaderValues result = spl.load(appDef, appValuesBuilder);
 		
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());


### PR DESCRIPTION
Also rm the need to pass cmdLineArgs thru various methods during AndHow
construction - the list is just given to the StringArgumentLoader at
construction time.