### PR TITLE
Sample configuration examples and errors now written as a big string

### DIFF
--- a/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
@@ -1,5 +1,6 @@
 package org.yarnandtail.andhow.internal;
 
+import java.io.*;
 import org.yarnandtail.andhow.util.AndHowUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,15 +94,44 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 			}
 		}
 		
-		//Print samples (if requested)
+		//Print samples (if requested) to System.out
 		if (Options.CREATE_SAMPLES.getValue(this)) {
-			ReportGenerator.printConfigSamples(runtimeDef, System.out, loaders, false);
+			
+			ByteArrayOutputStream os = new ByteArrayOutputStream();
+			PrintStream ps = new PrintStream(os);
+		
+			ReportGenerator.printConfigSamples(runtimeDef, ps, loaders, false);
+
+			try {
+				String message = os.toString("UTF8");
+				System.out.println(message);
+			} catch (UnsupportedEncodingException ex) {
+				//This shouldn't happen, but don't want to have the message burried
+				ReportGenerator.printConfigSamples(runtimeDef, System.out, loaders, true);
+			}
 		}
 	}
 	
+	/**
+	 * Prints failed startup details to System.err
+	 * 
+	 * @param afe 
+	 */
 	private void printFailedStartupDetails(AppFatalException afe) {
-		ReportGenerator.printProblems(System.err, afe, runtimeDef);
-		ReportGenerator.printConfigSamples(runtimeDef, System.err, loaders, true);
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		PrintStream ps = new PrintStream(os);
+		
+		ReportGenerator.printProblems(ps, afe, runtimeDef);
+		ReportGenerator.printConfigSamples(runtimeDef, ps, loaders, true);
+		
+		try {
+			String message = os.toString("UTF8");
+			System.err.println(message);
+		} catch (UnsupportedEncodingException ex) {
+			//This shouldn't happen, but don't want to have the message burried
+			ReportGenerator.printProblems(System.err, afe, runtimeDef);
+			ReportGenerator.printConfigSamples(runtimeDef, System.err, loaders, true);
+		}
 	}
 	
 	@Override

--- a/andhow/src/main/java/org/yarnandtail/andhow/util/AndHowUtil.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/util/AndHowUtil.java
@@ -1,6 +1,5 @@
 package org.yarnandtail.andhow.util;
 
-import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -109,12 +108,6 @@ public class AndHowUtil {
 		}
 		
 		return problems;
-	}
-		
-	public static void printExceptions(List<? extends Exception> exceptions, PrintStream out) {
-		for (Exception ne : exceptions) {
-			out.println(ne.getMessage());
-		}
 	}
 	
 	public static AppFatalException buildFatalException(ProblemList<Problem> problems) {


### PR DESCRIPTION
Previously using System.out/err, long messages would be interspersed w/
container error messages during failed startups.  By buffering into a
String first, it should be less likely that messages mix.
* rm unused method

fixes #212 