### PR TITLE
Issue210

### DIFF
--- a/andhow/src/main/java/org/yarnandtail/andhow/api/Property.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/api/Property.java
@@ -30,21 +30,63 @@ import java.util.List;
  */
 public interface Property<T> {
 
+	/**
+	 * Identical to the no-arg method, but for a localized domain.
+	 * 
+	 * getValue() with no arguments is the typical way to retrieve this
+	 * value.  This method allows a localized domain of values to be used.
+	 * 
+	 * @return May be null, unless the property is marked as required.
+	 */
 	T getValue(ValueMap values);
 	
+	/**
+	 * Returns the effective value of this property.
+	 * 
+	 * The effective value is the explicitly configured value, or if that is null,
+	 * the default value.
+	 * 
+	 * @return May be null, unless the property is marked as required.
+	 */
 	T getValue();
 	
+	/**
+	 * Identical to the no-arg method, but for a localized domain.
+	 * 
+	 * getExplicitValue() with no arguments is the typical way to retrieve this
+	 * value.  This method allows a localized domain of values to be used.
+	 * 
+	 * @return May be null
+	 */
 	T getExplicitValue(ValueMap values);
 	
+	/**
+	 * The value loaded for this value by a Loader from user configuration.
+	 * 
+	 * @return May be null
+	 */
 	T getExplicitValue();
 	
+	/**
+	 * The default value, as defined when this property was build.
+	 * 
+	 * @return May be null
+	 */
 	T getDefaultValue();
 	
+	/**
+	 * If true, the effective value must be non-null to be considered valid.
+	 * 
+	 * The effective value is the explicitly configured value, or if that is null,
+	 * the default value.
+	 * 
+	 * @return True if a non-null value is required.
+	 */
 	boolean isRequired();
 	
 	/**
 	 * The basic type of the property:  Flag, name/value, multi=value.
-	 * @return 
+	 * @return Never null
 	 */
 	PropertyType getPropertyType();
 	
@@ -52,7 +94,7 @@ public interface Property<T> {
 	 * The type of the value (String, Number, Integer, etc).
 	 * For Properties that allow multiple values (not yet implemented), an array
 	 * of values of the specified type can be fetched.
-	 * @return 
+	 * @return Never null
 	 */
 	ValueType<T> getValueType();
 	
@@ -60,19 +102,19 @@ public interface Property<T> {
 	 * The Trimmer responsible for trimming String values before they are converted
 	 * to the appropriate property type.
 	 * 
-	 * @return 
+	 * @return Never null
 	 */
 	Trimmer getTrimmer();
 	
 	/**
 	 * A short sentence description.
-	 * @return 
+	 * @return May be null
 	 */
 	String getShortDescription();
 	
 	/**
 	 * List of validators to validate the converted value.
-	 * @return 
+	 * @return An unmodifiable list of Validators.  Never null.
 	 */
 	List<Validator<T>> getValidators();
 	
@@ -102,7 +144,7 @@ public interface Property<T> {
 	/**
 	 * Added details that might be shown if the user requests help.
 	 * Assume that the short description is already shown.
-	 * @return 
+	 * @return May be null
 	 */
 	String getHelpText();
 

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/JndiLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/JndiLoader.java
@@ -37,7 +37,7 @@ public class JndiLoader extends BaseLoader {
 	@Override
 	public LoaderValues load(ConstructionDefinition appConfigDef, ValueMapWithContext existingValues) {
 
-		ArrayList<String> jndiRoots = buildJndiRoots(existingValues);
+		List<String> jndiRoots = buildJndiRoots(existingValues);
 
 		ArrayList<PropertyValue> values = new ArrayList();
 		ProblemList<Problem> problems = new ProblemList();
@@ -48,48 +48,32 @@ public class JndiLoader extends BaseLoader {
 
 			for (Property<?> prop : appConfigDef.getProperties()) {
 
-				//Check the URI name first (more likely), then the classpath style name
-				if (appConfigDef.getNamingStrategy().isUriNameDistict(appConfigDef.getCanonicalName(prop))) {
-					propNames.add(appConfigDef.getNamingStrategy().getUriName(appConfigDef.getCanonicalName(prop)));
-				}
+				
+				List<String> propJndiNames = buildJndiNames(appConfigDef, jndiRoots, prop);
+				
 
-				propNames.add(appConfigDef.getCanonicalName(prop));
 
-				//Add all of the 'in' aliases
-				appConfigDef.getAliases(prop).stream().filter(a -> a.isIn()).forEach(a -> {
-					propNames.add(a.getActualName());
+				for (String propName : propJndiNames) {
+					try {
+						Object o = ctx.lookup(propName);
 
-					//Add the URI style name if it is different
-					if (appConfigDef.getNamingStrategy().isUriNameDistict(a.getActualName())) {
-						propNames.add(appConfigDef.getNamingStrategy().getUriName(a.getActualName()));
-					}
-				});
+						if (o != null) {
+							attemptToAdd(appConfigDef, values, problems, prop, o);
+						}
 
-				for (String root : jndiRoots) {
-
-					for (String propName : propNames) {
-						try {
-							Object o = ctx.lookup(JNDI_PROTOCOL_NAME + root + propName);
-
-							if (o != null) {
-								attemptToAdd(appConfigDef, values, problems, prop, o);
-							}
-
-						} catch (NameNotFoundException nnfe) {
-							//Ignore - this is expected
-						} catch (NamingException ne) {
-							//Glassfish seems to be throwing this error w/
-							//a root cause of NameNotFound for simple NNF exceptions.
-							if (ne.getRootCause() instanceof NameNotFoundException) {
-								//Ignore - expected
-							} else {
-								throw ne;
-							}
+					} catch (NameNotFoundException nnfe) {
+						//Ignore - this is expected
+					} catch (NamingException ne) {
+						//Glassfish seems to be throwing this error w/
+						//a root cause of NameNotFound for simple NNF exceptions.
+						if (ne.getRootCause() instanceof NameNotFoundException) {
+							//Ignore - expected
+						} else {
+							throw ne;
 						}
 					}
 				}
 
-				propNames.clear();
 
 			}
 
@@ -126,46 +110,94 @@ public class JndiLoader extends BaseLoader {
 		return new JndiLoaderSamplePrinter();
 	}
 
-	protected ArrayList<String> buildJndiRoots(ValueMap values) {
+	/**
+	 * Combines the values of STANDARD_JNDI_ROOTS and ADDED_JNDI_ROOTS into one list of jndi root contexts to search.
+	 * 
+	 * Expected values might look like:  java:  or java:/comp/env/
+	 * 
+	 * @param values The configuration state.
+	 * @return Never null and never non-empty.
+	 */
+	protected List<String> buildJndiRoots(ValueMap values) {
 		ArrayList<String> myJndiRoots = new ArrayList();
 
-		List<String> someRoots = split(CONFIG.STANDARD_JNDI_ROOTS.getValue(values));
-		myJndiRoots.addAll(someRoots);
-
-		String addRoots = CONFIG.ADDED_JNDI_ROOTS.getValue(values);
-
-		if (addRoots != null) {
-			someRoots = split(addRoots);
-			myJndiRoots.addAll(someRoots);
+		//Add the added roots to the search list first, since they are pretty
+		//likely to be the correct ones if someone explicitly added them.
+		//We still check them all anyway, since a duplicate entry would be ambiguous.
+		if (CONFIG.ADDED_JNDI_ROOTS.getValue(values) != null) {
+			List<String> addRoots = split(CONFIG.ADDED_JNDI_ROOTS.getValue(values));
+			myJndiRoots.addAll(addRoots);
 		}
+		
+		List<String> addRoots = split(CONFIG.STANDARD_JNDI_ROOTS.getValue(values));
+		myJndiRoots.addAll(addRoots);
 
 		return myJndiRoots;
+	}
+	
+	/**
+	 * Builds a complete list of complete JNDI names to search for a parameter value.
+	 * 
+	 * @param appConfigDef
+	 * @param roots
+	 * @param prop
+	 * @return An ordered list of jndi names, with (hopefully) the most likely names first.
+	 */
+	protected List<String> buildJndiNames(ConstructionDefinition appConfigDef, List<String> roots, Property prop) {
+		
+		List<String> propNames = new ArrayList();		// w/o jndi root prefix
+		List<String> propJndiNames = new ArrayList();	// w/ jndi root prefix - return value
+
+		//Check the URI name first (more likely), then the classpath style name
+		if (appConfigDef.getNamingStrategy().isUriNameDistict(appConfigDef.getCanonicalName(prop))) {
+			propNames.add(appConfigDef.getNamingStrategy().getUriName(appConfigDef.getCanonicalName(prop)));
+		}
+
+		propNames.add(appConfigDef.getCanonicalName(prop));
+
+		//Add all of the 'in' aliases
+		appConfigDef.getAliases(prop).stream().filter(a -> a.isIn()).forEach(a -> {
+			propNames.add(a.getActualName());
+
+			//Add the URI style name if it is different
+			if (appConfigDef.getNamingStrategy().isUriNameDistict(a.getActualName())) {
+				propNames.add(appConfigDef.getNamingStrategy().getUriName(a.getActualName()));
+			}
+		});
+
+		for (String root : roots) {
+
+			for (String propName : propNames) {
+				propJndiNames.add(root + propName);
+			}
+		}
+		
+		return propJndiNames;
+
 	}
 
 	/**
 	 * Spits a comma separate list of JNDI roots into individual root strings.
 	 * 
-	 * Each non-empty root is given a trailing forward slash if it does not already
-	 * have one.
+	 * Use double quotes to indicate and preserve and empty or white space string.
 	 * 
 	 * @param rootStr
 	 * @return A list of JNDI root strings
 	 */
 	protected List<String> split(String rootStr) {
+		
+		List<String> cleanRoots = new ArrayList();
 
 		if (rootStr != null) {
 			QuotedSpacePreservingTrimmer trimmer = QuotedSpacePreservingTrimmer.instance();
 			String[] roots = rootStr.split(",");
 
 			for (int i = 0; i < roots.length; i++) {
-				roots[i] = trimmer.trim(roots[i]);
-
-				if (roots[i].length() > 0 && !(roots[i].endsWith("/"))) {
-					roots[i] = roots[i] + "/";
-				}
+				String s = trimmer.trim(roots[i]);
+				if (s != null) cleanRoots.add(s);
 			}
 
-			return Arrays.asList(roots);
+			return cleanRoots;
 		} else {
 			return TextUtil.EMPTY_STRING_LIST;
 		}
@@ -174,27 +206,28 @@ public class JndiLoader extends BaseLoader {
 
 	@GroupInfo(
 			name = "JndiLoader Configuration",
-			desc = "Since application containers use various JNDI roots to store "
-			+ "environment varibles, these properties allow customization. "
-			+ "The most common roots are \"\" or \"comp/env/\". "
-			+ "If your container uses something different, set one of these properties. "
-			+ "All configured JNDI roots will be searched for each application property. "
-			+ "For both properties, trailing slashes will automcatically be added, "
-			+ "however, a leading slash is significant - "
-			+ "is non-standard but allowed and your properties must match.")
+			desc = "Since JNDI providers use different base URIs to store "
+			+ "entries, base URIs must be configurable. "
+			+ "The most common URI roots are \"java:\", \"java:comp/env/\" or just \"\"."
+			+ "To preserve whitespace or indicate an empty string, use double quotes around an individual comma separated value."
+			+ "If your container/provider uses something different, set one of these properties. "
+			+ "All configured JNDI roots will be searched for each application property."
+			+ "Typically there are multiple roots to search and multiple forms of "
+			+ "property names, leading to the possibility of duplicate/conflicting JNDI entries. "
+			+ "If multiple entries are found in JNDI for a property, a runtime error is thrown at startup.")
 	public static interface CONFIG extends BasePropertyGroup {
 
 		StrProp STANDARD_JNDI_ROOTS = StrProp.builder()
-				.defaultValue("comp/env/, \"\"")
+				.defaultValue("java:comp/env/,java:,\"\"").required()
 				.desc("A comma separated list of standard JNDI root locations to be searched for properties. "
 						+ "Setting this property will replace the standard list, "
 						+ "use ADDED_JNDI_ROOTS to only add to the list. ")
-				.helpText("The final JNDI URIs to be searched will look like this 'java:[root]/[Property Name]'").build();
+				.helpText("The final JNDI URIs to be searched will look like this '[root][Property Name]'").build();
 
 		StrProp ADDED_JNDI_ROOTS = StrProp.builder()
-				.desc("A comma separated list of JNDI root locations to be added to the standard list for searching. "
+				.desc("A comma separated list of JNDI root locations to be prepended to the standard list for searching. "
 						+ "Setting this property does not affect the STANDARD_JNDI_ROOTS.")
-				.helpText("The final JNDI URIs to be searched will look like this 'java:[root]/[Property Name]'").build();
+				.helpText("The final JNDI URIs to be searched will look like this '[root][Property Name]'").build();
 
 	}
 	

--- a/andhow/src/test/java/org/yarnandtail/andhow/load/JndiLoaderTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/load/JndiLoaderTest.java
@@ -30,17 +30,24 @@ public class JndiLoaderTest extends AndHowTestBase {
 		JndiLoader loader = new JndiLoader();
 		
 		//This is the default
-		List<String> result = loader.split("comp/env/, \"\"");
+		List<String> result = loader.split("java:comp/env/, \"\",");
 		assertEquals(2, result.size());
-		assertEquals("comp/env/", result.get(0));
+		assertEquals("java:comp/env/", result.get(0));
 		assertEquals("", result.get(1));
 		
-		//Should add a trailing slash if missing
-		result = loader.split(" comp/env , \"_\",x/y/z");
+		//Should leave prefix completely unmodified (not add a trailing slash)
+		result = loader.split(" comp/env , , \"_\",x/y/z");
 		assertEquals(3, result.size());
-		assertEquals("comp/env/", result.get(0));
-		assertEquals("_/", result.get(1));
-		assertEquals("x/y/z/", result.get(2));
+		assertEquals("comp/env", result.get(0));
+		assertEquals("_", result.get(1));
+		assertEquals("x/y/z", result.get(2));
+		
+		//Should be able to indicate an empty string and whitespace w/ double quotes.
+		result = loader.split(" comp/env , \"\" , \" \"");
+		assertEquals(3, result.size());
+		assertEquals("comp/env", result.get(0));
+		assertEquals("", result.get(1));
+		assertEquals(" ", result.get(2));
 	}
 
 
@@ -52,15 +59,15 @@ public class JndiLoaderTest extends AndHowTestBase {
 		
 		jndi.bind("java:comp/env/" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_TRUE)), "false");
 		jndi.bind("java:comp/env/" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_FALSE)), "true");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_NULL)), "TRUE");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.INT_TEN)), "-999");
 		jndi.bind("java:comp/env/" + 
 				bns.getUriName(AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.INT_NULL)), "999");
@@ -98,11 +105,11 @@ public class JndiLoaderTest extends AndHowTestBase {
 		SimpleNamingContextBuilder jndi = AndHowTestBase.getJndi();
 
 		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.STR_BOB), "test");
-		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
-		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_TRUE), "false");
+		jndi.bind("java:" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
+		jndi.bind("" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_TRUE), "false");
 		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_FALSE), "true");
-		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
-		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.INT_TEN), "-999");
+		jndi.bind("java:" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
+		jndi.bind("" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.INT_TEN), "-999");
 		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.INT_NULL), "999");
 		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.LNG_TEN), "-999");
 		jndi.bind("java:comp/env/" + AndHowUtil.getCanonicalName(SimpleParams.class, SimpleParams.LNG_NULL), "999");
@@ -149,7 +156,7 @@ public class JndiLoaderTest extends AndHowTestBase {
 		jndi.activate();
 		
 		AndHow.builder()
-				.loader(new FixedValueLoader(new PropertyValue(JndiLoader.CONFIG.ADDED_JNDI_ROOTS, "/test,    test  ,   myapp/root")))
+				.loader(new FixedValueLoader(new PropertyValue(JndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/,    java:test/  ,   java:myapp/root/")))
 				.loader(new JndiLoader())
 				.group(SimpleParams.class)
 				.reloadForNonPropduction(reloader);
@@ -183,8 +190,8 @@ public class JndiLoaderTest extends AndHowTestBase {
 		
 		AndHow.builder()
 				.loader(new FixedValueLoader(
-						new PropertyValue(JndiLoader.CONFIG.STANDARD_JNDI_ROOTS, "zip,xy/z/"),
-						new PropertyValue(JndiLoader.CONFIG.ADDED_JNDI_ROOTS, "/test,    test  ,   myapp/root")
+						new PropertyValue(JndiLoader.CONFIG.STANDARD_JNDI_ROOTS, "java:zip/,java:xy/z/"),
+						new PropertyValue(JndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/  ,  ,java:test/ , java:myapp/root/")
 				))
 				.loader(new JndiLoader())
 				.group(SimpleParams.class)


### PR DESCRIPTION
The JNDILoader was inflexible and assumed a lot in how JNDI urls were constructed.  The sped is actually really loose, so more flexibility was provided and better extensibility.

The change could affect people who have customized JNDI roots via configuration, but that would be no-one at this point.

fixes #210, fixes #208 