### PR TITLE
Now printing error and samples w/ a leading line separator

### DIFF
--- a/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
@@ -104,7 +104,9 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 
 			try {
 				String message = os.toString("UTF8");
-				System.out.println(message);
+				
+				//Add separator prefix to prevent log prefixes from indenting 1st line
+				System.out.println(System.lineSeparator() + message);
 			} catch (UnsupportedEncodingException ex) {
 				//This shouldn't happen, but don't want to have the message burried
 				ReportGenerator.printConfigSamples(runtimeDef, System.out, loaders, true);
@@ -126,7 +128,9 @@ public class AndHowCore implements ConstructionDefinition, ValueMap {
 		
 		try {
 			String message = os.toString("UTF8");
-			System.err.println(message);
+			
+			//Add separator prefix to prevent log prefixes from indenting 1st line
+			System.err.println(System.lineSeparator() + message);
 		} catch (UnsupportedEncodingException ex) {
 			//This shouldn't happen, but don't want to have the message burried
 			ReportGenerator.printProblems(System.err, afe, runtimeDef);


### PR DESCRIPTION
This prevents some containers (GlassFish) from messing up the
indentation of the first line by leading it with 'SEVERE:'

Fixes #224 