### PR TITLE
AndHowLogging instances were created as subclasses of java.util.Logger

### DIFF
--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor.java
@@ -26,7 +26,7 @@ import static javax.tools.StandardLocation.CLASS_OUTPUT;
  */
 @SupportedAnnotationTypes("*")
 public class AndHowCompileProcessor extends AbstractProcessor {
-	private static final AndHowLog LOG = new AndHowLog(AndHowCompileProcessor.class);
+	private static final AndHowLog LOG = AndHowLog.getLogger(AndHowCompileProcessor.class);
 	
 	private static final String SERVICES_PACKAGE = "";
 	
@@ -43,25 +43,6 @@ public class AndHowCompileProcessor extends AbstractProcessor {
 	public AndHowCompileProcessor() {
 		//required by Processor API
 		runDate = new GregorianCalendar();
-		
-		//Update the logger settings.
-		//Only once instance will be created, so setting a static here is a non-issue
-		String pkg = AndHowCompileProcessor.class.getPackage().getName();
-		String propName = pkg + ".LogLevel";
-		String logLevelStr = System.getProperty(propName);
-		
-		if (logLevelStr != null) {
-			try {
-				Level level = Level.parse(logLevelStr.toUpperCase());
-				LOG.setLevel(level);
-				LOG.logrb(Level.SEVERE, AndHowCompileProcessor.class.getCanonicalName(), 
-						null, null, "Set log level to {0} for package {1}", level.getName(), pkg);
-			} catch (IllegalArgumentException ex) {
-				LOG.logrb(Level.SEVERE, AndHowCompileProcessor.class.getCanonicalName(), 
-						null, null, "Unrecognized level ''{0}'' for {1} must match a java.util.logging.Level", logLevelStr, propName);
-			}
-		}
-		
 	}
 	
 	protected void addRegistrar(String fullClassName, Element causeElement) {

--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowElementScanner7.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowElementScanner7.java
@@ -20,7 +20,7 @@ import static javax.lang.model.util.ElementFilter.*;
  * @author ericeverman
  */
 public class AndHowElementScanner7 extends ElementScanner7<CompileUnit, String> {
-	private static final AndHowLog LOG = new AndHowLog(AndHowElementScanner7.class);
+	private static final AndHowLog LOG = AndHowLog.getLogger(AndHowElementScanner7.class);
 
 	private final Types typeUtils;
 	private final TypeElement propertyTypeElem;

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -1,5 +1,6 @@
 package org.yarnandtail.andhow;
 
+import java.io.File;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -110,6 +111,11 @@ public class AndHowTest extends AndHowTestBase {
 			
 			ConstructionProblem.DuplicateLoader dl = (ConstructionProblem.DuplicateLoader)ce.getProblems().filter(ConstructionProblem.class).get(0);
 			assertEquals(loaders.get(0), dl.getLoader());
+			assertTrue(ce.getSampleDirectory().length() > 0);
+			
+			File sampleDir = new File(ce.getSampleDirectory());
+			assertTrue(sampleDir.exists());
+			assertTrue(sampleDir.listFiles().length > 0);
 		}
 	}
 	

--- a/andhow/src/main/java/org/yarnandtail/andhow/util/AndHowLog.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/util/AndHowLog.java
@@ -1,6 +1,8 @@
 package org.yarnandtail.andhow.util;
 
+import java.util.Arrays;
 import java.util.logging.*;
+import java.util.logging.Logger;
 
 /**
  * A simple wrapper around the java.util.Logging utility that makes it behave
@@ -26,26 +28,38 @@ import java.util.logging.*;
  *
  * @author ericeverman
  */
-public class AndHowLog extends java.util.logging.Logger {
+public class AndHowLog {
 
 	private static final AndHowLogHandler DEFAULT_HANDLER = new AndHowLogHandler();
 	private static final String CN = AndHowLog.class.getCanonicalName();
 
 	private final Class<?> clazz;
-
-	public AndHowLog(Class<?> clazz) {
-		super(clazz.getCanonicalName(), null);
-
-		super.addHandler(DEFAULT_HANDLER);
-
-		this.clazz = clazz;
-		reloadLogLevel();
+	private final Logger baseLogger;
+	
+	public static AndHowLog getLogger(Class<?> clazz) {
+		Logger baseLog = Logger.getLogger(clazz.getCanonicalName());
+		return new AndHowLog(baseLog, clazz);
+	}
+	
+	public static AndHowLog getLogger(Class<?> clazz, Handler handler) {
+		Logger baseLog = Logger.getLogger(clazz.getCanonicalName());
+		return new AndHowLog(baseLog, clazz, handler);
+	}
+	
+	private AndHowLog(Logger baseLog, Class<?> clazz) {
+		this(baseLog, clazz, null);
 	}
 
-	public AndHowLog(Class<?> clazz, Handler handler) {
-		super(clazz.getCanonicalName(), null);
+	private AndHowLog(Logger baseLog, Class<?> clazz, Handler handler) {
+		baseLogger = baseLog;
+		
+		if (handler == null) {
+			handler = DEFAULT_HANDLER;
+		}
 
-		super.addHandler(handler);
+		if (! Arrays.asList(baseLogger.getHandlers()).contains(handler)) {
+			baseLogger.addHandler(handler);
+		}
 
 		this.clazz = clazz;
 		reloadLogLevel();
@@ -62,139 +76,162 @@ public class AndHowLog extends java.util.logging.Logger {
 	 * @param newLevel
 	 * @throws SecurityException
 	 */
-	@Override
 	public void setLevel(Level newLevel) throws SecurityException {
 
 		if (newLevel != null) {
-			super.setLevel(newLevel);
+			baseLogger.setLevel(newLevel);
 		} else {
 			reloadLogLevel();
 		}
 	}
+	
+	public Handler[] getHandlers() {
+		return baseLogger.getHandlers();
+	}
+	
+	public void addHandler(Handler handler) {
+		baseLogger.addHandler(handler);
+	}
+	
+	public void removeHandler(Handler handler) {
+		baseLogger.removeHandler(handler);
+	}
+	
+   /**
+     * Check if a message of the given level would actually be logged
+     * by this logger.  This check is based on the Loggers effective level,
+     * which may be inherited from its parent.
+     *
+     * @param   level   a message logging level
+     * @return  true if the given message level is currently being logged.
+     */
+    public boolean isLoggable(Level level) {
+        return baseLogger.isLoggable(level);
+    }
 
 	private void reloadLogLevel() {
 		String levelProp = clazz.getCanonicalName() + ".level";
 		String levelStr = System.getProperty(levelProp);
 
 		if (levelStr != null) {
-			super.setLevel(Level.parse(levelStr));
+			baseLogger.setLevel(Level.parse(levelStr));
 		} else {
-			super.setLevel(null);
+			baseLogger.setLevel(null);
 		}
 	}
 
 	//
 	//Trace
 	public void trace(String msg) {
-		if (isLoggable(Level.FINEST)) {
+		if (baseLogger.isLoggable(Level.FINEST)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
+			baseLogger.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
 		}
 	}
 
 	public void trace(String format, Object... arguments) {
-		if (isLoggable(Level.FINEST)) {
+		if (baseLogger.isLoggable(Level.FINEST)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
+			baseLogger.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
 		}
 	}
 
 	public void trace(String msg, Throwable t) {
-		if (isLoggable(Level.FINEST)) {
+		if (baseLogger.isLoggable(Level.FINEST)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
+			baseLogger.logp(Level.FINEST, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
 		}
 	}
 
 	//
 	//Debug
 	public void debug(String msg) {
-		if (isLoggable(Level.FINE)) {
+		if (baseLogger.isLoggable(Level.FINE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
+			baseLogger.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
 		}
 	}
 
 	public void debug(String format, Object... arguments) {
-		if (isLoggable(Level.FINE)) {
+		if (baseLogger.isLoggable(Level.FINE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
+			baseLogger.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
 		}
 	}
 
 	public void debug(String msg, Throwable t) {
-		if (isLoggable(Level.FINE)) {
+		if (baseLogger.isLoggable(Level.FINE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
+			baseLogger.logp(Level.FINE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
 		}
 	}
 
 	//
 	//Info
 	public void info(String msg) {
-		if (isLoggable(Level.INFO)) {
+		if (baseLogger.isLoggable(Level.INFO)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
+			baseLogger.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
 		}
 	}
 
 	public void info(String format, Object... arguments) {
-		if (isLoggable(Level.INFO)) {
+		if (baseLogger.isLoggable(Level.INFO)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
+			baseLogger.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
 		}
 	}
 
 	public void info(String msg, Throwable t) {
-		if (isLoggable(Level.INFO)) {
+		if (baseLogger.isLoggable(Level.INFO)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
+			baseLogger.logp(Level.INFO, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
 		}
 	}
 
 	//
 	//Warn
 	public void warn(String msg) {
-		if (isLoggable(Level.WARNING)) {
+		if (baseLogger.isLoggable(Level.WARNING)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
+			baseLogger.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
 		}
 	}
 
 	public void warn(String format, Object... arguments) {
-		if (isLoggable(Level.WARNING)) {
+		if (baseLogger.isLoggable(Level.WARNING)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
+			baseLogger.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
 		}
 	}
 
 	public void warn(String msg, Throwable t) {
-		if (isLoggable(Level.WARNING)) {
+		if (baseLogger.isLoggable(Level.WARNING)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
+			baseLogger.logp(Level.WARNING, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
 		}
 	}
 
 	//
 	//Error
 	public void error(String msg) {
-		if (isLoggable(Level.SEVERE)) {
+		if (baseLogger.isLoggable(Level.SEVERE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
+			baseLogger.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg);
 		}
 	}
 
 	public void error(String format, Object... arguments) {
-		if (isLoggable(Level.SEVERE)) {
+		if (baseLogger.isLoggable(Level.SEVERE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
+			baseLogger.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), format, arguments);
 		}
 	}
 
 	public void error(String msg, Throwable t) {
-		if (isLoggable(Level.SEVERE)) {
+		if (baseLogger.isLoggable(Level.SEVERE)) {
 			StackTraceElement ste = StackLocator.getInstance().calcLocation(CN);
-			super.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
+			baseLogger.logp(Level.SEVERE, ste.getClassName(), ste.getMethodName() + ":" + ste.getLineNumber(), msg, t);
 		}
 	}
 

--- a/andhow/src/test/java/org/yarnandtail/andhow/util/AndHowLogTest.java
+++ b/andhow/src/test/java/org/yarnandtail/andhow/util/AndHowLogTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
  */
 public class AndHowLogTest {
 	
-	private static AndHowLog log = new AndHowLog(AndHowLogTest.class);
+	private static AndHowLog log = AndHowLog.getLogger(AndHowLogTest.class);
 	
 
 	ByteArrayOutputStream testErrByteArray;


### PR DESCRIPTION
AndHowLogging instances were created as subclasses of java.util.Logger, which caused an undefined state when the Logger constructor was called for a logger name that already existed. Logger handles this by not allowing direct construction - I just uses a static getLogger method that checks to see if the logger exists in the registry hash map. Direct construction had now way to handle this, so the AndHowLogger now uses the same strategy. In the case where the Logger already is registered, a new AndHowLogger wrapper is created for it.