### PR TITLE
Better assurance that validation is run on all properties

### DIFF
--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/map/EarthMapMakerTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/map/EarthMapMakerTest.java
@@ -80,7 +80,7 @@ public class EarthMapMakerTest extends AndHowTestBase {
 		SimpleNamingContextBuilder jndi = getJndi();
 		jndi.bind("java:" + "com.map.EarthMapMaker.MAP_NAME", "JndiPropMapName");
 		jndi.bind("java:" + "com.map.EarthMapMaker.SOUTH_BOUND", "7");
-		jndi.bind("java:comp/env/" + "org.dataprocess.ExternalServiceConnector.ConnectionConfig.SERVICE_URL", "test");
+		jndi.bind("java:comp/env/" + "org.dataprocess.ExternalServiceConnector.ConnectionConfig.SERVICE_URL", "test/");
 		jndi.activate();
 		
 		//VALUES IN THE PROPS FILE
@@ -94,7 +94,7 @@ public class EarthMapMakerTest extends AndHowTestBase {
 		
 		
 		ExternalServiceConnector esc = new ExternalServiceConnector();
-		assertEquals("http://forwardcorp.com/service/", esc.getConnectionUrl());
+		assertEquals("test/", esc.getConnectionUrl());
 		assertEquals(60, esc.getConnectionTimeout());
 		
 		EarthMapMaker emm = new EarthMapMaker();

--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
@@ -1,7 +1,6 @@
 package org.dataprocess;
 
 import org.junit.Test;
-import org.yarnandtail.andhow.AndHowNonProduction;
 import org.yarnandtail.andhow.AndHowTestBase;
 
 import static org.junit.Assert.*;
@@ -21,8 +20,6 @@ public class ExternalServiceConnectorTest extends AndHowTestBase {
 	 */
 	@Test
 	public void testAllConfigValues() {
-		AndHowNonProduction.builder().build();
-		
 		ExternalServiceConnector esc = new ExternalServiceConnector();
 		assertEquals("http://forwardcorp.com/service/", esc.getConnectionUrl());
 		assertEquals(60, esc.getConnectionTimeout());

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.yarnandtail.andhow.AndHowNonProduction;
-import org.yarnandtail.andhow.AndHowTestBase;
-import org.yarnandtail.andhow.PropertyGroup;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.RequirementProblem;
 import org.yarnandtail.andhow.load.StringArgumentLoader;

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -16,6 +16,7 @@ public interface SimpleParams extends PropertyGroup {
 	//Strings
 	StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 	StrProp STR_NULL = StrProp.builder().aliasInAndOut("String_Null").build();
+	StrProp STR_END_XXX = StrProp.builder().mustEndWith("XXX").build();
 	
 	//Flags
 	FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).build();
@@ -25,16 +26,20 @@ public interface SimpleParams extends PropertyGroup {
 	//Integers
 	IntProp INT_TEN = IntProp.builder().defaultValue(10).build();
 	IntProp INT_NULL = IntProp.builder().build();
+	IntProp INT_BIG_TEN = IntProp.builder().mustBeGreaterThan(10).build();
 	
 	//Long
 	LngProp LNG_TEN = LngProp.builder().defaultValue(10L).build();
 	LngProp LNG_NULL = LngProp.builder().build();
+	LngProp LNG_LESS_TEN = LngProp.builder().mustBeLessThan(10L).build();
 	
 	//Double
 	DblProp DBL_TEN = DblProp.builder().defaultValue(10d).build();
 	DblProp DBL_NULL = DblProp.builder().build();
+	DblProp DBL_LESS_ZERO = DblProp.builder().mustBeLessThan(0).build();
 	
 	//LocalDateTime
 	LocalDateTimeProp LDT_2007_10_01 = LocalDateTimeProp.builder().defaultValue(LocalDateTime.parse("2007-10-01T00:00")).build();
 	LocalDateTimeProp LDT_NULL = LocalDateTimeProp.builder().build();
+	LocalDateTimeProp LDT_AFTER_2000 = LocalDateTimeProp.builder().mustBeAfter(LocalDateTime.parse("2000-01-01T00:00")).build();
 }

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderAppTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/load/PropertyFileOnClasspathLoaderAppTest.java
@@ -5,17 +5,16 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.AndHowNonProduction;
 import org.yarnandtail.andhow.PropertyGroup;
 import org.yarnandtail.andhow.SimpleParams;
 import org.yarnandtail.andhow.api.AppFatalException;
+import org.yarnandtail.andhow.api.Problem;
 import org.yarnandtail.andhow.internal.ConstructionProblem.LoaderPropertyNotRegistered;
 import org.yarnandtail.andhow.internal.LoaderProblem.SourceNotFoundLoaderProblem;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.StrProp;
 import org.yarnandtail.andhow.internal.ConstructionProblem.LoaderPropertyIsNull;
-import org.yarnandtail.andhow.load.PropertyFileOnClasspathLoader;
 import org.yarnandtail.andhow.util.NameUtil;
 
 /**
@@ -46,6 +45,26 @@ public class PropertyFileOnClasspathLoaderAppTest {
 		assertEquals(Boolean.FALSE, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(Boolean.TRUE, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(Boolean.TRUE, SimpleParams.FLAG_NULL.getValue());
+	}
+	
+	@Test
+	public void testInvalid() throws Exception {
+		
+		try {
+			AndHowNonProduction.builder().namingStrategy(new CaseInsensitiveNaming())
+					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH), 
+							"/org/yarnandtail/andhow/load/SimpleParamsInvalid.properties")
+					.loader(new PropertyFileOnClasspathLoader(TestProps.CLAZZ_PATH))
+					.group(SimpleParams.class)
+					.group(TestProps.class)
+					.build();
+		
+				fail("The property file contains several invalid props - should have errored");
+		} catch (AppFatalException afe) {
+			List<Problem> probs = afe.getProblems();
+			assertEquals(5, probs.size());
+		}
+
 	}
 	
 	@Test
@@ -88,7 +107,7 @@ public class PropertyFileOnClasspathLoaderAppTest {
 	}
 	
 	/**
-	 * It is not an error to not specify the classpath param, it just means the laoder
+	 * It is not an error to not specify the classpath param, it just means the loader
 	 * will not find anything.
 	 * 
 	 * @throws Exception 

--- a/andhow-system-tests/src/test/resources/org/yarnandtail/andhow/load/SimpleParamsInvalid.properties
+++ b/andhow-system-tests/src/test/resources/org/yarnandtail/andhow/load/SimpleParamsInvalid.properties
@@ -1,0 +1,20 @@
+org.yarnandtail.andhow.SimpleParams.STR_BOB = kvpBobValue
+org.yarnandtail.andhow.SimpleParams.STR_NULL = kvpNullValue
+org.yarnandtail.andhow.SimpleParams.FLAG_FALSE = true
+org.yarnandtail.andhow.SimpleParams.FLAG_TRUE = false
+org.yarnandtail.andhow.SimpleParams.FLAG_NULL = true
+
+# Should end w XXX
+org.yarnandtail.andhow.SimpleParams.STR_XXX = somethingYYY
+
+#Should be larger than 10 (== 10 not good enough)
+org.yarnandtail.andhow.SimpleParams.INT_BIG_TEN: 10
+
+# Should be less than 10 (== 10 not good enough)
+org.yarnandtail.andhow.SimpleParams.LNG_LESS_TEN 10
+
+# Should be less than zero
+org.yarnandtail.andhow.SimpleParams.DBL_LESS_ZERO : 1
+
+# Should be after 2000
+org.yarnandtail.andhow.SimpleParams.LDT_AFTER_2000 1999-12-31T00:00

--- a/andhow/src/main/java/org/yarnandtail/andhow/api/Loader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/api/Loader.java
@@ -5,6 +5,9 @@ import java.util.List;
 /**
  * Each instance is responsible for loading values from a particular type of
  * source.
+ * 
+ * The central method is load(), which is responsible for loading property
+ * values and registering loader-level problems into a LoaderValues object.
  *
  * Implementations may define a set of Properties used to control the behavior
  * of all instances of a loader, which are returned from getClassConfig().
@@ -24,8 +27,15 @@ import java.util.List;
 public interface Loader {
 	
 	/**
-	 * Builds up a list of LoaderValues by loading property values from a configuration
-	 * source.
+	 * Builds up a list of LoaderValues by loading property values from a
+	 * configuration source.
+	 * 
+	 * Loaders find and load values and associate them with the correct Property.
+	 * If there is a problem while doing that, they register one or more
+	 * LoaderProblems in the returned LoaderValues.
+	 * 
+	 * Validation of Property values is not Loader's responsibility and will be
+	 * handled outside this method.
 	 * 
 	 * @param runtimeDef
 	 * @param existingValues

--- a/andhow/src/main/java/org/yarnandtail/andhow/internal/ReportGenerator.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/internal/ReportGenerator.java
@@ -3,14 +3,10 @@ package org.yarnandtail.andhow.internal;
 import java.io.*;
 import java.util.HashSet;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.yarnandtail.andhow.AndHow;
 import org.yarnandtail.andhow.Options;
 import org.yarnandtail.andhow.api.*;
-import org.yarnandtail.andhow.util.IOUtil;
-import org.yarnandtail.andhow.util.TextUtil;
-import org.yarnandtail.andhow.util.AndHowLog;
+import org.yarnandtail.andhow.util.*;
 
 /**
  *

--- a/andhow/src/main/java/org/yarnandtail/andhow/internal/ValueProblem.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/internal/ValueProblem.java
@@ -2,7 +2,6 @@ package org.yarnandtail.andhow.internal;
 
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.util.TextUtil;
-import org.yarnandtail.andhow.api.BasePropertyGroup;
 
 /**
  * Problems with invalid values, values that cannot be converted to their destination type.

--- a/andhow/src/main/java/org/yarnandtail/andhow/load/BaseLoader.java
+++ b/andhow/src/main/java/org/yarnandtail/andhow/load/BaseLoader.java
@@ -7,7 +7,6 @@ import org.yarnandtail.andhow.internal.LoaderProblem;
 import org.yarnandtail.andhow.internal.LoaderProblem.DuplicatePropertyLoaderProblem;
 import org.yarnandtail.andhow.internal.LoaderProblem.ObjectConversionValueProblem;
 import org.yarnandtail.andhow.internal.LoaderProblem.UnknownPropertyLoaderProblem;
-import org.yarnandtail.andhow.internal.ValueProblem;
 import org.yarnandtail.andhow.util.TextUtil;
 
 /**
@@ -152,7 +151,6 @@ public abstract class BaseLoader implements Loader {
 	protected <T> PropertyValue createValue(GlobalScopeConfiguration appConfigDef, 
 			Property<T> prop, String untrimmedString) throws ParsingException {
 		
-		ProblemList<Problem> problems = new ProblemList();
 		T value = null;
 		
 		String trimmed = untrimmedString;
@@ -168,17 +166,11 @@ public abstract class BaseLoader implements Loader {
 
 			value = prop.getValueType().parse(trimmed);
 
-			for (Validator<T> v : prop.getValidators()) {
-				if (! v.isValid(value)) {
-					problems.add(new ValueProblem.InvalidValueProblem(
-							this, appConfigDef.getGroupForProperty(prop).getProxiedGroup(), prop, value, v));
-				}
-			}
 		} else {
 			return null;	//No value to create
 		}
 		
-		return new PropertyValue(prop, value, problems);
+		return new PropertyValue(prop, value);
 	}
 	
 }


### PR DESCRIPTION
* Moved validation from Loader responsibility to AndHowCore, where it is not possible to bypass as it was w/ Loader implementations
* Added several more tests around checking for validation
* To allow ValueProblems to be discovered after loading, the PropertyValue class now has an addProblem() method and is no longer unmodifiable
* AndHowCore has new doPropertyValidations() method where all prop validation happens
* Added JNDI to the app tests and cleaned them up a bit.