### PR TITLE
Accept cmd line args and fixed values to the AndHowConfiguration that will be used

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
@@ -7,10 +7,18 @@ import org.yarnandtail.andhow.api.*;
  *
  * @author ericeverman
  */
-public interface AndHowConfiguration {
+public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	List<Loader> buildLoaders();
 	
 	List<GroupProxy> getRegisteredGroups();
 
 	NamingStrategy getNamingStrategy();
+	
+	C setCmdLineArgs(String[] commandLineArgs);
+	
+	<T> C addFixedValue(Property<T> property, T value);
+	
+	C removeFixedValue(Property<?> property);
+	
+	void build();
 }

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/BaseConfig.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/BaseConfig.java
@@ -15,7 +15,7 @@ import org.yarnandtail.andhow.util.AndHowUtil;
  * @param <C> The class to return from each of the fluent builder methods, which
  * will be the implementation class in each case.  See StdConfig for an example.
  */
-public abstract class BaseConfig<C extends BaseConfig<C>> implements AndHowConfiguration {
+public abstract class BaseConfig<C extends BaseConfig<C>> implements AndHowConfiguration<C> {
 
 	protected static final Class<?>[] DEFAULT_LOADER_LIST = new Class<?>[] {
 		StdFixedValueLoader.class, StdMainStringArgsLoader.class,
@@ -156,6 +156,11 @@ public abstract class BaseConfig<C extends BaseConfig<C>> implements AndHowConfi
 		PropertyRegistrarLoader registrar = new PropertyRegistrarLoader();
 		List<GroupProxy> registeredGroups = registrar.getGroups();
 		return registeredGroups;
+	}
+	
+	@Override
+	public void build() {
+		AndHow.instance(this);
 	}
 	
 	/**

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
@@ -41,6 +41,7 @@ public class StdConfig {
 		 * @param value The value to set.
 		 * @return
 		 */
+		@Override
 		public <T> S addFixedValue(Property<T> property, T value) {
 
 			if (property == null) {
@@ -68,6 +69,7 @@ public class StdConfig {
 		 * @param property A non-null property.
 		 * @return
 		 */
+		@Override
 		public S removeFixedValue(Property<?> property) {
 
 			if (property == null) {
@@ -92,34 +94,11 @@ public class StdConfig {
 		 * @param commandLineArgs
 		 * @return
 		 */
-		public S addCmdLineArgs(String[] commandLineArgs) {
+		@Override
+		public S setCmdLineArgs(String[] commandLineArgs) {
 
 			if (commandLineArgs != null && commandLineArgs.length > 0) {
 				_cmdLineArgs.addAll(Arrays.asList(commandLineArgs));
-			}
-
-			return (S) this;
-		}
-
-		/**
-		 * Adds a command line argument in key=value form.
-		 *
-		 * If the value is null, only the key is added (ie its a flag).
-		 *
-		 * @param key
-		 * @param value
-		 * @return
-		 */
-		public S addCmdLineArg(String key, String value) {
-
-			if (key == null) {
-				throw new RuntimeException("The key cannot be null");
-			}
-
-			if (value != null) {
-				_cmdLineArgs.add(key + KeyValuePairLoader.KVP_DELIMITER + value);
-			} else {
-				_cmdLineArgs.add(key);
 			}
 
 			return (S) this;

--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java
@@ -23,8 +23,8 @@ public class EarthMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
 	
 	@Test
 	public void testA_ConfigFromSysProps() {
-		System.out.println("testConfigFromSysProps");
-		
+
+		System.setProperty("EMM.LogServer", "http://localhost.logger/EMM/");
 		System.setProperty("com.dep1.EarthMapMaker.MAP_NAME", "SysPropMapName");
 		System.setProperty("com.dep1.EarthMapMaker.EAST_BOUND", "-99");
 		
@@ -33,14 +33,21 @@ public class EarthMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
 		EarthMapMaker emm = new EarthMapMaker();
 		
 		//Actual values
+		assertEquals("http://localhost.logger/EMM/", emm.getLogServerUrl());
 		assertEquals("SysPropMapName", emm.getMapName());
 		assertEquals(-99, emm.getEastBound());
 	}
 	
+	/**
+	 * This test should be ordered between the other two tests (see @FixMethodOrder on class)
+	 * 
+	 * The outer two tests force a custom construction.  This test doesn't not
+	 * force configuration to see if the configuration specified by the auto-discovered
+	 * TestInitiation class is used.
+	 */
 	@Test
 	public void testB_ZeroConfig() {
-		System.out.println("testZeroConfig");
-		
+
 		EarthMapMaker emm = new EarthMapMaker();
 		
 		//These values set in the TestInitiation (discovered automatically)
@@ -57,13 +64,12 @@ public class EarthMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
 	
 	@Test
 	public void testC_ConfigFromCmdLineThenSysProps() {
-		System.out.println("testConfigFromCmdLineThenSysProps");
-		
+
 		System.setProperty("com.dep1.EarthMapMaker.MAP_NAME", "SysPropMapName");
 		System.setProperty("com.dep1.EarthMapMaker.EAST_BOUND", "-99");
 		
 
-		NonProductionConfig.instance().addCmdLineArgs(new String[] {
+		NonProductionConfig.instance().setCmdLineArgs(new String[] {
 					"com.dep1.EarthMapMaker.MAP_NAME=CmdLineMapName",
 					"com.dep1.EarthMapMaker.WEST_BOUND=-179"})
 				.forceBuild();

--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerUsingAHBaseTestClassTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerUsingAHBaseTestClassTest.java
@@ -63,7 +63,7 @@ public class MarsMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
 		System.setProperty("com.dep2.MarsMapMaker.EAST_BOUND", "-99");
 		
 
-		NonProductionConfig.instance().addCmdLineArgs(new String[] {
+		NonProductionConfig.instance().setCmdLineArgs(new String[] {
 					"com.dep2.MarsMapMaker.MAP_NAME=CmdLineMapName",
 					"com.dep2.MarsMapMaker.WEST_BOUND=-179"})
 				.forceBuild();

--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
@@ -51,16 +51,36 @@ public class EarthMapMakerTest extends AndHowTestBase {
 	}
 	
 	@Test
-	public void testConfigFromCmdLineThenSysProps() {
+	public void testConfigFromCmdLineThenSysPropsViaNonProdConfigForceBuild() {
 		
 		System.setProperty("com.dep1.EarthMapMaker.MAP_NAME", "SysPropMapName");
 		System.setProperty("com.dep1.EarthMapMaker.EAST_BOUND", "-99");
 		
 
-		NonProductionConfig.instance().addCmdLineArgs(new String[] {
+		NonProductionConfig.instance().setCmdLineArgs(new String[] {
 					"com.dep1.EarthMapMaker.MAP_NAME=CmdLineMapName",
 					"com.dep1.EarthMapMaker.WEST_BOUND=-179"})
 				.forceBuild();
+		
+		EarthMapMaker emm = new EarthMapMaker();
+		
+		//Actual values
+		assertEquals("CmdLineMapName", emm.getMapName());
+		assertEquals(-99, emm.getEastBound());
+		assertEquals(-179, emm.getWestBound());
+	}
+	
+	@Test
+	public void testConfigFromCmdLineThenSysPropsViaProdConfigUtilForceBuild() {
+		
+		System.setProperty("com.dep1.EarthMapMaker.MAP_NAME", "SysPropMapName");
+		System.setProperty("com.dep1.EarthMapMaker.EAST_BOUND", "-99");
+		
+		AndHowNonProductionUtil.forceRebuild(
+		AndHow.findConfig().setCmdLineArgs(new String[] {
+					"com.dep1.EarthMapMaker.MAP_NAME=CmdLineMapName",
+					"com.dep1.EarthMapMaker.WEST_BOUND=-179"})
+		);
 		
 		EarthMapMaker emm = new EarthMapMaker();
 		
@@ -113,7 +133,7 @@ public class EarthMapMakerTest extends AndHowTestBase {
 		
 		try {
 			NonProductionConfig.instance()
-					.addCmdLineArgs(new String[] {
+					.setCmdLineArgs(new String[] {
 						"com.dep1.EarthMapMaker.MAP_NAME=CmdLineMapName",
 						"com.dep1.EarthMapMaker.WEST_BOUND=-179"})
 					.forceBuild();

--- a/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
+++ b/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
@@ -58,7 +58,7 @@ public class MarsMapMakerTest extends AndHowTestBase {
 		System.setProperty("com.dep2.MarsMapMaker.EAST_BOUND", "-99");
 		
 
-		NonProductionConfig.instance().addCmdLineArgs(new String[] {
+		NonProductionConfig.instance().setCmdLineArgs(new String[] {
 					"com.dep2.MarsMapMaker.MAP_NAME=CmdLineMapName",
 					"com.dep2.MarsMapMaker.WEST_BOUND=-179"})
 				.forceBuild();
@@ -114,7 +114,7 @@ public class MarsMapMakerTest extends AndHowTestBase {
 		
 		try {
 			NonProductionConfig.instance()
-					.addCmdLineArgs(new String[] {
+					.setCmdLineArgs(new String[] {
 						"com.dep2.MarsMapMaker.MAP_NAME=CmdLineMapName",
 						"com.dep2.MarsMapMaker.WEST_BOUND=-179"})
 					.forceBuild();

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -69,7 +69,7 @@ public class AndHowTest extends AndHowTestBase {
 	public void testCmdLineLoaderUsingClassBaseName() {
 		NonProductionConfig.instance()
 				.groups(configPtGroups)
-				.addCmdLineArgs(cmdLineArgsWFullClassName)
+				.setCmdLineArgs(cmdLineArgsWFullClassName)
 				.forceBuild();
 		
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
@@ -123,7 +123,7 @@ public class AndHowTest extends AndHowTestBase {
 				NonProductionConfig.instance()
 					.groups(configPtGroups)
 					.group(RequiredParams.class)
-					.addCmdLineArgs(cmdLineArgsWFullClassName)
+					.setCmdLineArgs(cmdLineArgsWFullClassName)
 					.forceBuild();
 			
 			fail();	//The line above should throw an error

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -40,7 +40,7 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 	public void testAllValuesAreSet() {
 		NonProductionConfig.instance()
 				.group(UI_CONFIG.class).group(SERVICE_CONFIG.class)
-				.addCmdLineArgs(cmdLineArgsWFullClassName)
+				.setCmdLineArgs(cmdLineArgsWFullClassName)
 				.forceBuild();
 		
 		assertEquals("My App", UI_CONFIG.DISPLAY_NAME.getValue());

--- a/andhow-system-tests/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
+++ b/andhow-system-tests/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
@@ -42,7 +42,7 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 		
 		NonProductionConfig.instance()
 				.group(SampleRestClientGroup.class)
-				.addCmdLineArgs(cmdLineArgs)
+				.setCmdLineArgs(cmdLineArgs)
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired()
 				.forceBuild();
@@ -70,7 +70,7 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 				
 		NonProductionConfig.instance()
 				.group(SampleRestClientGroup.class)
-				.addCmdLineArgs(cmdLineArgs)
+				.setCmdLineArgs(cmdLineArgs)
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired()
 				.forceBuild();
@@ -103,7 +103,7 @@ public class SampleRestClientAppTest extends AndHowTestBase {
 			//Error expected b/c some values are invalid
 			NonProductionConfig.instance()
 					.group(SampleRestClientGroup.class)
-					.addCmdLineArgs(cmdLineArgs)
+					.setCmdLineArgs(cmdLineArgs)
 					.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 					.classpathPropertiesRequired()
 					.forceBuild();

--- a/andhow-test-harness/src/main/java/org/yarnandtail/andhow/NonProductionConfig.java
+++ b/andhow-test-harness/src/main/java/org/yarnandtail/andhow/NonProductionConfig.java
@@ -7,6 +7,7 @@ import org.yarnandtail.andhow.service.PropertyRegistrarLoader;
 import org.yarnandtail.andhow.util.AndHowUtil;
 import org.yarnandtail.andhow.StdConfig.StdConfigAbstract;
 import org.yarnandtail.andhow.api.Loader;
+import org.yarnandtail.andhow.load.KeyValuePairLoader;
 
 /**
  *
@@ -30,6 +31,34 @@ public class NonProductionConfig {
 		
 		//If non-empty, it overrides the default list of loaders
 		protected final List<Loader> _loaders = new ArrayList();
+		
+
+		/**
+		 * Adds a command line argument in key=value form.
+		 *
+		 * If the value is null, only the key is added (ie its a flag).
+		 * This method is added as a convenience to the NonProductionConfig
+		 * because during testing command line arguments are often simulated
+		 * rather than passed in as a set.
+		 *
+		 * @param key
+		 * @param value
+		 * @return
+		 */
+		public N addCmdLineArg(String key, String value) {
+
+			if (key == null) {
+				throw new RuntimeException("The key cannot be null");
+			}
+
+			if (value != null) {
+				_cmdLineArgs.add(key + KeyValuePairLoader.KVP_DELIMITER + value);
+			} else {
+				_cmdLineArgs.add(key);
+			}
+
+			return (N) this;
+		}
 		
 
 		/**

--- a/andhow-usage-examples/complex-example/src/main/java/net/spacebase/SpaceBaseApplication.java
+++ b/andhow-usage-examples/complex-example/src/main/java/net/spacebase/SpaceBaseApplication.java
@@ -25,7 +25,7 @@ public class SpaceBaseApplication {
 	 * @param args 
 	 */
 	public static void main(String[] args) {
-		AndHow.instance( StdConfig.instance().addCmdLineArgs(args) );
+		AndHow.instance( StdConfig.instance().setCmdLineArgs(args) );
 		
 		System.out.println("Spacebase App is started!");
 		singleton = new SpaceBaseApplication();

--- a/andhow-usage-examples/force-print-config-example/src/main/java/howto/force/config/sample/printing/ReallySimpleApp.java
+++ b/andhow-usage-examples/force-print-config-example/src/main/java/howto/force/config/sample/printing/ReallySimpleApp.java
@@ -12,7 +12,7 @@ import org.yarnandtail.andhow.*;
 public class ReallySimpleApp {
 	
 	public static void main(String[] args) {
-		AndHow.instance( StdConfig.instance().addCmdLineArgs(args) );
+		AndHow.instance( StdConfig.instance().setCmdLineArgs(args) );
 	
 		System.out.println("Examples of using the configured properties (they initially have default values)");
 		System.out.println("The query url is: " + MySetOfProps.SERVICE_URL.getValue());

--- a/andhow-usage-examples/simple-example/src/test/java/org/simple/GettingStartedTest.java
+++ b/andhow-usage-examples/simple-example/src/test/java/org/simple/GettingStartedTest.java
@@ -47,7 +47,7 @@ public class GettingStartedTest extends AndHowTestBase {
 	
 	@Test
 	public void testLaunch3_UsingCommandLineArguments() throws Exception {
-		NonProductionConfig.instance().addCmdLineArgs(new String[] {
+		NonProductionConfig.instance().setCmdLineArgs(new String[] {
 			"org.simple.GettingStarted.COUNT_DOWN_START=3",
 			"org.simple.GettingStarted.LAUNCH_COMMAND=GoManGo!"
 		}).forceBuild();


### PR DESCRIPTION


* Add a AndHow.findConfig() method that returns the current config
* Add cmd line args and fixed values to the AndHowConfiguration Interface
* Add build() to the Config interface
* Improved documentation

Fixes #283 