### PR TITLE
Appveyor ci#312

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,10 @@ install:
   - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
-  - cmd: C:\ProgramData\chocolatey\bin\mvn --version
+  - cmd: C:\ProgramData\chocolatey\bin\mvn.exe --version
   - cmd: java -version
 build_script:
-  - C:\ProgramData\chocolatey\bin\mvn clean install
+  - C:\ProgramData\chocolatey\bin\mvn.exe clean install
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,16 +6,15 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
-  # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
+  # Prepend Maven and Java entries, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: choco upgrade maven
-  - cmd: C:\ProgramData\chocolatey\bin\RefreshEnv
-  - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
+  - cmd: SET PATH=C:\ProgramData\chocolatey\bin;JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn clean install
+  - mvn.exe clean install
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,13 @@ environment:
 install:
   # Prepend Maven and Java entries, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: choco upgrade maven
-  - cmd: SET PATH=C:\ProgramData\chocolatey\bin;JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
+  - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
-  - cmd: mvn --version
+  - cmd: C:\ProgramData\chocolatey\bin\mvn --version
   - cmd: java -version
 build_script:
-  - mvn.exe clean install
+  - C:\ProgramData\chocolatey\bin\mvn clean install
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
+  - cmd: dir C:\maven\
   - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: '{build}'
+skip_tags: true
+clone_depth: 10
+environment:
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+install:
+  # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
+  - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
+  - cmd: mvn --version
+  - cmd: java -version
+build_script:
+  - mvn clean install
+cache:
+  - C:\maven\ -> appveyor.yml
+  - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: dir C:\maven\
+  - cmd: choco upgrade maven
+  - cmd: C:\ProgramData\chocolatey\bin\RefreshEnv
   - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,15 @@ skip_tags: true
 clone_depth: 10
 environment:
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    # Append additional lines defining new values of JAVA_HOME to test multiple versions
 install:
-  # Prepend Maven and Java entries, remove Ruby entry (C:\Ruby193\bin;) from PATH
+  # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: choco upgrade maven
   - cmd: SET PATH=%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
+  # Print debug info
   - cmd: C:\ProgramData\chocolatey\bin\mvn.exe --version
   - cmd: java -version
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 install:
   # Prepend Maven and Java entries, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: choco upgrade maven
-  - cmd: SET PATH=JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
+  - cmd: SET PATH=%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: C:\ProgramData\chocolatey\bin\mvn.exe --version


### PR DESCRIPTION
Addresses #312.

The instructions for enabling Appveyor on this repo are very similar to those for Travis CI(see comment on #311).

Demonstration that the appveyor process is working, but with the tools.jar error:
https://ci.appveyor.com/project/carlschroedl/andhow/build/8

Here's a demonstration that the appveyor and tools.jar branches produce a successful build when merged onto master:
https://ci.appveyor.com/project/carlschroedl/andhow/build/12