### PR TITLE
Cleanup to support building on JDK9 and forward

### DIFF
--- a/andhow-annotation-processor/pom.xml
+++ b/andhow-annotation-processor/pom.xml
@@ -46,10 +46,6 @@
 			<groupId>com.google.testing.compile</groupId>
 			<artifactId>compile-testing</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowElementScanner7.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowElementScanner7.java
@@ -14,7 +14,7 @@ import static javax.lang.model.util.ElementFilter.*;
 /**
  * This Scanner is only intended to work on a single compileable unit at a time.
  *
- * Do not use the scan(Iterable<? extends Element>) method defined in the super
+ * Do not use the {@code scan(Iterable<? extends Element>)} method defined in the super
  * class.
  *
  * @author ericeverman

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
@@ -6,7 +6,6 @@ import org.yarnandtail.andhow.property.StrProp;
 import org.yarnandtail.andhow.util.TextUtil;
 
 /**
- * <S extends StdConfig<S>>
  * @author ericeverman
  */
 public class StdConfig {
@@ -81,7 +80,7 @@ public class StdConfig {
 		 * StdPropFileOnClasspathLoader to load.
 		 *
 		 * If no path is specified via either a String or StrProp, the path
-		 * '/andhow.properties' is used.<br/>
+		 * '/andhow.properties' is used.<br>
 		 *
 		 * Paths should start with a forward slash and have packages delimited by
 		 * forward slashes. If the file name contains a dot, the path <em>must</em>
@@ -115,7 +114,7 @@ public class StdConfig {
 		 * properties file for the StdPropFileOnClasspathLoader to load.
 		 *
 		 * If no path is specified via either a String or StrProp, the path
-		 * '/andhow.properties' is used.<br/>
+		 * '/andhow.properties' is used.<br>
 		 *
 		 * Paths should start with a forward slash and have packages delimited by
 		 * forward slashes. If the file name contains a dot, the path <em>must</em>

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/api/LocalFileLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/api/LocalFileLoader.java
@@ -10,7 +10,7 @@ public interface LocalFileLoader {
 	/**
 	 * Sets the path to the file to be loaded.
 	 * 
-	 * Setting this non-null is mutually exclusive with setting the Property<String>
+	 * Setting this non-null is mutually exclusive with setting the Property{@code <String>}
 	 * based method of the same name.
 	 * 
 	 * @param path 

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/api/Name.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/api/Name.java
@@ -13,7 +13,7 @@ public class Name {
 	 * with characters allowed in various formats, in particular, uri style JNDI
 	 * names or property files conventions.
 	 *
-	 * URLs require encoding for these characters: [whitespace];/?:@=&"<>#%{}|\^~[]`
+	 * URLs require encoding for these characters: {@code [whitespace];/?:@=&"<>#%{}|\^~[]`}
 	 */
 	public static String ILLEGAL_PROPERTY_NAME_CHARS = " \t\n\r;/?:@=&\"<>#%{}|\\^~[]`";
 

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdEnvVarLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdEnvVarLoader.java
@@ -7,7 +7,7 @@ import org.yarnandtail.andhow.load.MapLoader;
 /**
  * Reads the operating system defined environment variables and loads the value
  * for any environmental variable who's name matches a Property.
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li>StdMainStringArgsLoader
@@ -17,7 +17,7 @@ import org.yarnandtail.andhow.load.MapLoader;
  * <li>StdPropFileOnFilesystemLoader
  * <li>StdPropFileOnClasspathLoader
  * </ul>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * An application might receive all or some of its configuration from OS defined
  * environmental variables that are passed to the JVM when the JVM starts.
  * Environment variables can be set in the OS and augmented in a startup script,
@@ -25,14 +25,14 @@ import org.yarnandtail.andhow.load.MapLoader;
  * Similar to Java system properties, this provides a relatively easy way for
  * deployment automation or system administrators to control application
  * configuration values across many servers.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: No</b>
  * <li><b>Default behavior:  AndHow always attempts to read environment
  * variables and will assign property values if any of them match known property names.</b>
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * This loader loads values from {@code System.getenv()}.
  * Those environmental values are provided by the host environment (the OS)
  * as a static snapshot to the JVM at startup as a String-to-String map.
@@ -47,7 +47,7 @@ import org.yarnandtail.andhow.load.MapLoader;
  * are case sensitive - This is the primary reason AndHow is case insensitive
  * by default.  Each OS <a href="https://www.schrodinger.com/kb/1842">
  * has a different way to set an environmental variables</a>
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdFixedValueLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdFixedValueLoader.java
@@ -6,7 +6,7 @@ import org.yarnandtail.andhow.load.FixedValueLoader;
 /**
  * Sets values directly in code.
  * 
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li><b>StdFixedValueLoader &lt;-- This loader</b>
  * <li>StdMainStringArgsLoader
@@ -18,19 +18,19 @@ import org.yarnandtail.andhow.load.FixedValueLoader;
  * </ul>
  * <em>Property value loading is based on a 'first win' strategy, so the first
  * loader to find a value for a property sets the value.</em>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * Since this loader uses fixed values in code, it is only useful for specifying
  * configuration of your application during testing.  Configuration values can
  * be directly set in code so that your application can be tested in a specific
  * configured state.  Since this is the first loader, a property value set by
  * this load will override configuration values found by any other loader.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: NA</b> - This is not possible
  * <li><b>Default behavior:  None</b> - This loader is only active if values are directly set as shown below
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * One simple way to set fixed values is shown below.  AndHow will discover this
  * class implementing the {@code AndHowInit} interface during initialization to
  * read your configuration.  That looks like this:
@@ -50,7 +50,7 @@ import org.yarnandtail.andhow.load.FixedValueLoader;
  * Alternatively you can use {@code AndHow.findConfig()} at an application entry
  * point such as the main method.
  * 
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdJndiLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdJndiLoader.java
@@ -17,7 +17,7 @@ import org.yarnandtail.andhow.util.TextUtil;
 /**
  * Attempts to look up the name of each known {@code Property} in the JNDI
  * environment and loads the value for any that are found.
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li>StdMainStringArgsLoader
@@ -27,11 +27,11 @@ import org.yarnandtail.andhow.util.TextUtil;
  * <li>StdPropFileOnFilesystemLoader
  * <li>StdPropFileOnClasspathLoader
  * </ul>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * A web or service application runs in an application container such as Tomcat.
  * Application containers provide a JNDI environment which can be used to
  * configure applications running in their environment.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: No</b>
@@ -39,7 +39,7 @@ import org.yarnandtail.andhow.util.TextUtil;
  * <li><b>Default behavior:  Always attempts to look up each Property in the JNDI environment</b>
  * <li><b>Is case sensitive: Yes</b> (This is one of the only loaders that is case sensitive)
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * While most other loaders are case insensitive, the JNDI loader is case
  * sensitive because the JNDI API is case sensitive.
  * Also, while most other loaders consume a configuration resource
@@ -95,7 +95,7 @@ import org.yarnandtail.andhow.util.TextUtil;
  * <pre>
  * java -Dorg.yarnandtail.andhow.load.std.StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS=java:xyz/ -jar MyJarName.jar
  * </pre>
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdMainStringArgsLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdMainStringArgsLoader.java
@@ -7,7 +7,7 @@ import org.yarnandtail.andhow.load.KeyValuePairLoader;
  * Reads an array of Strings containing key value pairs in the form <em>key=value</em>,
  * and loads the value for any key that matches a Property.  This is normally
  * used to read in command line arguments.
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li><b>StdMainStringArgsLoader &lt;-- This loader</b>
@@ -19,20 +19,20 @@ import org.yarnandtail.andhow.load.KeyValuePairLoader;
  * </ul>
  * <em>Property value loading is based on a 'first win' strategy, so the first
  * loader to find a value for a property sets the value.</em>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * An executable jar or desktop application accepts command line arguments at
  * startup to configure the application.  This loader loads the
  * {@code String[] args} passed to the {@code main(String[] args)}, which Java
  * passes from the command line.  This is the most common usage, however, your
  * application may retrieve an array of {@code String}'s from anywhere to pass
  * to AndHow at startup.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: Yes</b>
  * <li><b>Complains about unrecognized properties: No</b>
  * <li><b>Default behavior:  None</b> - This loader is only active if command line arguments are passed in as shown below
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * AndHow is not 'there' to somehow intercept command line arguments -
  * Your application code will need to do that and pass those arguments to
  * AndHow, like this:
@@ -53,7 +53,7 @@ import org.yarnandtail.andhow.load.KeyValuePairLoader;
  * <a href="https://sites.google.com/view/andhow/usage-examples/main-startup-example">
  * Here is a complete example of using command line arguments</a>.
  * 
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnClasspathLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnClasspathLoader.java
@@ -9,7 +9,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * <em>classpath</em>. By default, this loader will look for a file named
  * {@code andhow.properties} at the root of the classpath.
  * 
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li>StdMainStringArgsLoader
@@ -21,20 +21,20 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * </ul>
  * <em>Property value loading is based on a 'first win' strategy, so the first
  * loader to find a value for a property sets the value.</em>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * A service application might load the majority of its configuration from
  * system properties or environmental variables, however, some sane default
  * configuration values can be bundled with the application.
  * By default, AndHow will discover and load a file named {@code andhow.properties}
  * at the root of the classpath via the {@code StdPropFileOnClasspathLoader}.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: Yes</b>
  * <li><b>Complains if the .properties file is missing: No</b>
  * <li><b>Default behavior:  Attempts to read {@code andhow.properties} from the root of the classpath</b>
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * This loader reads properties files using the {@code java.util.Properties},
  * which silently ignores duplicate property entries
  * (i.e., the same key appearing multiple times).  When there are duplicate 
@@ -72,7 +72,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * If a value is present, the loader tries to load from the configured classpath.
  * If no value is configured, the default classpath is assumed.
  * 
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnFilesystemLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnFilesystemLoader.java
@@ -7,7 +7,7 @@ import org.yarnandtail.andhow.load.PropFileOnFilesystemLoader;
  * Parses and loads Properties from a Java {@code .property} file on the
  * <em>file system</em>.  Since file systems vary, there is no default filepath
  * that AndHow attempts to load from. 
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li>StdMainStringArgsLoader
@@ -19,20 +19,20 @@ import org.yarnandtail.andhow.load.PropFileOnFilesystemLoader;
  * </ul>
  * <em>Property value loading is based on a 'first win' strategy, so the first
  * loader to find a value for a property sets the value.</em>
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  *  A service application might load minimal configuration from system
  * properties or environmental variables, loading the bulk of its configuration
  * from a properties file on the file system.  The properties file is not part
  * of the application, so it survives redeployments.  A single environmental or
  * system property could then be used to specify the properties file.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: Yes</b>
  * <li><b>Complains if the .properties file is missing: Yes (if a file path is configured)</b>
  * <li><b>Default behavior:  None - If not explicitly configured, no default loading is attempted.</b>
  * </ul>
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * This loader reads properties files using the {@code java.util.Properties},
  * which silently ignores duplicate property entries
  * (i.e., the same key appearing multiple times).  When there are duplicate 
@@ -67,7 +67,7 @@ import org.yarnandtail.andhow.load.PropFileOnFilesystemLoader;
  * If a value is present, the loader tries to load from the configured file
  * system path.  If no value is configured, this loader is skipped.
  * 
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdSysPropLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdSysPropLoader.java
@@ -7,7 +7,7 @@ import org.yarnandtail.andhow.load.MapLoader;
 /**
  * Reads the Java system properties and loads the value for any system property
  * who's name matches a Property.
- * <h4>Position in Standard Loading Order, first to last</h4>
+ * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
  * <li>StdMainStringArgsLoader
@@ -20,13 +20,13 @@ import org.yarnandtail.andhow.load.MapLoader;
  * <em>Property value loading is based on a 'first win' strategy, so the first
  * loader to find a value for a property sets the value.</em>
  * 
- * <h4>Typical Use Case</h4>
+ * <h3>Typical Use Case</h3>
  * An application might receive all or some of its configuration from Java
  * system properties that are set when the JVM starts.  Java system properties
  * can be set in a startup script, which could be customized for each environment.
  * This provides a relatively easy way for deployment automation or system
  * administrators to control application configuration values across many servers.
- * <h4>Basic Behaviors</h4>
+ * <h3>Basic Behaviors</h3>
  * <ul>
  * <li><b>Pre-trims String values: No</b> (Individual Properties may still trim values)
  * <li><b>Complains about unrecognized properties: No</b>
@@ -35,7 +35,7 @@ import org.yarnandtail.andhow.load.MapLoader;
  * match known property names.</b>
  * </ul>
  * 
- * <h4>Loader Details and Configuration</h4>
+ * <h3>Loader Details and Configuration</h3>
  * This loader loads properties from {@code java.lang.System.getProperties()}.
  * Over the lifecycle of the JVM, values of system properties can change
  * so this loader is working from a snapshot of the system properties it finds
@@ -51,7 +51,7 @@ import org.yarnandtail.andhow.load.MapLoader;
  * Passing system properties on command line looks like this:
  * <pre>java -Dfull.name.of.MY_PROPERTY=someValue -jar MyJarName.jar</pre>
  * 
- * <h4>This is a Standard Loader</h4>
+ * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
  * via the {@code AndHowConfiguration.setStandardLoaders()} methods.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
@@ -141,7 +141,7 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	 * 
 	 * If the alias name already exists, it will add 'in-ness' to it.
 	 * Alias names cannot be null, contain whitespace, or these characters:
-	 * <code>;/?:@=&"&lt;&gt;>#%{}|\^~[]`</code>
+	 * <code>{@code ;/?:@=&"&lt;&gt;>#%{}|\^~[]`}</code>
 	 * @param name
 	 * @return A builder for chaining build calls
 	 */
@@ -156,7 +156,7 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	 * 
 	 * If the alias name already exists, it will add 'out-ness' to it.
 	 * Alias names cannot be null, contain whitespace, or these characters:
-	 * <code>;/?:@=&"<>#%{}|\^~[]`</code>
+	 * <code>{@code ;/?:@=&"<>#%{}|\^~[]`}</code>
 	 * 
 	 * @param name
 	 * @return A builder for chaining build calls
@@ -172,7 +172,7 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	 * 
 	 * If the alias name already exists, it will add 'in' and 'out' to it.
 	 * Alias names cannot be null, contain whitespace, or these characters:
-	 * <code>;/?:@=&"<>#%{}|\^~[]`</code>
+	 * <code>{@code ;/?:@=&"<>#%{}|\^~[]`}</code>
 	 * 
 	 * @param name
 	 * @return A builder for chaining build calls

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/service/AbstractPropertyRegistrar.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/service/AbstractPropertyRegistrar.java
@@ -8,7 +8,7 @@ import java.util.List;
  * Provides a minimal implementation of {@code PropertyRegistrar} to simplify
  * code that must be generated.
  * 
- * <h4>Property registration background</h4>
+ * <h3>Property registration background</h3>
  * At compile time, the AndHowCompileProcessor (an annotation Processor), reads
  * user classes and generates a PropertyRegistrar instance for each root class
  * (non-inner class) that contains an AndHow {@code Property}.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistrar.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistrar.java
@@ -10,7 +10,7 @@ import java.util.List;
  * final artifact (typically a jar, war or ear file), which can be discovered
  * automatically via the {@code java.util.ServiceLoader} mechanism.
  * 
- * <h4>Property registration background</h4>
+ * <h3>Property registration background</h3>
  * At compile time, the AndHowCompileProcessor (an annotation Processor), reads
  * user classes and generates a PropertyRegistrar instance for each root class
  * (non-inner class) that contains an AndHow {@code Property}.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistration.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistration.java
@@ -7,7 +7,7 @@ import java.util.*;
  * Registration for a single Property, which registers a single {@code Property}
  * with AndHow during startup at run time.
  * 
- * <h4>Property registration background</h4>
+ * <h3>Property registration background</h3>
  * At compile time, the AndHowCompileProcessor (an annotation Processor), reads
  * user classes and generates a PropertyRegistrar instance for each root class
  * (non-inner class) that contains an AndHow {@code Property}.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistrationList.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/service/PropertyRegistrationList.java
@@ -18,7 +18,7 @@ import java.util.*;
  * a 'get' method.  The get method will likely only be called once during its
  * lifecycle.
  * 
- * <h4>Property registration background</h4>
+ * <h3>Property registration background</h3>
  * At compile time, the AndHowCompileProcessor (an annotation Processor), reads
  * user classes and generates a PropertyRegistrar instance for each root class
  * (non-inner class) that contains an AndHow {@code Property}.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/util/NameUtil.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/util/NameUtil.java
@@ -158,8 +158,8 @@ public class NameUtil {
 	/**
 	 * Gets the true canonical name for a Property in the group.
 	 *
-	 * The canonical name is of the form:<br/>
-	 * [group canonical name].[field name of the Property within the group]<br/>
+	 * The canonical name is of the form:<br>
+	 * [group canonical name].[field name of the Property within the group]<br>
 	 * thus, it is require that the Property be a field within the group,
 	 * otherwise null is returned.
 	 *

--- a/andhow/pom.xml
+++ b/andhow/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -95,34 +95,19 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-test</artifactId>
-				<version>4.3.5.RELEASE</version>
+				<version>4.3.18.RELEASE</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.5</version>
+				<version>2.6</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.google.testing.compile</groupId>
 				<artifactId>compile-testing</artifactId>
-				<version>0.12</version>
-				
-				<!-- comp-test has conflicting versions of guava -->
-				<exclusions>
-					<exclusion>
-						<groupId>com.google.guava</groupId>
-						<artifactId>guava</artifactId>
-					</exclusion>
-				</exclusions>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<!-- fixed for compile-testing -->
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>21.0</version>
+				<version>0.15</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>
@@ -134,12 +119,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.6.2</version>
+					<version>3.8.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
+					<version>3.0.1</version>
 					<configuration>
 						<additionalparam>-Xdoclint:none</additionalparam>
 						<quiet>true</quiet>
@@ -178,15 +163,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<compilerVersion>1.8</compilerVersion> 
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
@@ -197,6 +173,14 @@
 					</formats>
 					<check />
 					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<generateBackupPoms>false</generateBackupPoms>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -231,7 +215,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.4</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -285,22 +269,71 @@
 			</build>
 		</profile>
 		<profile>
-			<id>default-tools.jar</id>
+			<id>AllJDK8</id>
 			<activation>
-				<property>
-					<name>java.vendor</name>
-					<value>Sun Microsystems Inc.</value>
-				</property>
+				<jdk>[1.8,1.9)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>1.8</source>
+							<target>1.8</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>SomeJDK8s</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<file>
+					<exists>${java.home}/../lib/tools.jar</exists>
+				</file>
 			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.sun</groupId>
 					<artifactId>tools</artifactId>
-					<version>1.4.2</version>
+					<version>1.8</version>
 					<scope>system</scope>
 					<systemPath>${java.home}/../lib/tools.jar</systemPath>
 				</dependency>
 			</dependencies>
+		</profile>
+		<profile>
+			<id>java9AndBeyond</id>
+			<!--
+			Its not possible to build a JRE 1.8 compatable jar file using JDK9
+			because of the need to use the '-add-modules' feature of JDK9.
+			Currently the use of jdk9 is blocked by the enforcer plugin, above.
+			For the 0.5.0 release, the JRE8 will be left behind and only this
+			profile will be active.
+			-->
+			<activation>
+				<jdk>[1.9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<compilerArgs>
+								<arg>--add-modules=jdk.compiler</arg>
+							</compilerArgs>
+							<!-- without forking compilation happens in the
+							same process, so no arguments are applied -->
+							<fork>true</fork>
+							<source>1.9</source>
+							<target>1.9</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
fixes #349 
* Added a profile for JDK9+ that uses the new Jigsaw -add-module to include jdk.compile, which includes the functionality previously in the tools.jar
* Update all plugins and several dependencies to versions that support JDK9
* Lots of javadoc cleanup for syntax errors that were tripping up the JDK9 javadocs