### PR TITLE
Modifying DblValidator unit tests

### DIFF
--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
@@ -112,6 +112,7 @@ public class DblValidatorTest {
 		assertTrue(instance.isValid(4d));
 		assertTrue(instance.isValid(5d));
 		assertFalse(instance.isValid(6d));
+		assertFalse(instance.isValid(null));
 		
 		instance = new DblValidator.LessThanOrEqualTo(0d);
 		assertTrue(instance.isValid(-1d));

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
  */
 public class DblValidatorTest {
 
+	private static String EXPECTED_DBL_VALIDATOR_INVALID_MESSAGE = "THIS VALIDATION IS ALWAYS VALID";
+
 	@Test
 	public void testGreaterThanIsSpecificationValid() {
 		DblValidator.GreaterThan instance = new DblValidator.GreaterThan(5d);
@@ -24,6 +26,7 @@ public class DblValidatorTest {
 		assertFalse(instance.isValid(4d));
 		assertFalse(instance.isValid(5d));
 		assertTrue(instance.isValid(6d));
+		assertFalse(instance.isValid(null));
 		
 		instance = new DblValidator.GreaterThan(0d);
 		assertFalse(instance.isValid(-1d));
@@ -51,6 +54,7 @@ public class DblValidatorTest {
 		assertFalse(instance.isValid(4d));
 		assertTrue(instance.isValid(5d));
 		assertTrue(instance.isValid(6d));
+		assertFalse(instance.isValid(null));
 		
 		instance = new DblValidator.GreaterThanOrEqualTo(0d);
 		assertFalse(instance.isValid(-1d));
@@ -80,6 +84,7 @@ public class DblValidatorTest {
 		assertTrue(instance.isValid(4d));
 		assertFalse(instance.isValid(5d));
 		assertFalse(instance.isValid(6d));
+		assertFalse(instance.isValid(null));
 		
 		instance = new DblValidator.LessThan(0d);
 		assertTrue(instance.isValid(-1d));
@@ -120,6 +125,29 @@ public class DblValidatorTest {
 		
 	}
 	
+	@Test
+	public void testGreaterThanInvalidSpecificationMessage() {
+		DblValidator.GreaterThan instance = new DblValidator.GreaterThan(5d);
+		assertEquals(EXPECTED_DBL_VALIDATOR_INVALID_MESSAGE, instance.getInvalidSpecificationMessage());
+	}
+
+	@Test
+	public void testGreaterThanOrEqualToInvalidSpecificationMessage() {
+		DblValidator.GreaterThanOrEqualTo instance = new DblValidator.GreaterThanOrEqualTo(5d);
+		assertEquals(EXPECTED_DBL_VALIDATOR_INVALID_MESSAGE, instance.getInvalidSpecificationMessage());
+	}
+
+	@Test
+	public void testLessThanInvalidSpecificationMessage() {
+		DblValidator.LessThan instance = new DblValidator.LessThan(5d);
+		assertEquals(EXPECTED_DBL_VALIDATOR_INVALID_MESSAGE, instance.getInvalidSpecificationMessage());
+	}
+
+	@Test
+	public void testLessThanOrEqualToInvalidSpecificationMessage() {
+		DblValidator.LessThanOrEqualTo instance = new DblValidator.LessThanOrEqualTo(5d);
+		assertEquals(EXPECTED_DBL_VALIDATOR_INVALID_MESSAGE, instance.getInvalidSpecificationMessage());
+	}
 
 	
 }


### PR DESCRIPTION
## Changes made

1. Added a null parameter on the `isValid()` method to all test cases which implements `DblValidator`
2. Added tests for `InvalidSpecificationMessage()`

Since most of the tests are repeated, I was thinking of refactoring some of the lines into a common method. But i'm not sure about the contribution guidelines (IMO unit tests should be as atomic as possible rather than refactoring)

Addresses #392 