### PR TITLE
Reduced warnings during build process

### DIFF
--- a/andhow/pom.xml
+++ b/andhow/pom.xml
@@ -56,19 +56,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>javadoc-jar</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-
-						<configuration>
-							<includeDependencySources>true</includeDependencySources>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -140,10 +140,24 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.0.1</version>
-					<configuration>
-						<additionalparam>-Xdoclint:none</additionalparam>
-						<quiet>true</quiet>
-					</configuration>
+					<inherited>true</inherited>
+					<executions>
+						<execution>
+							<id>javadoc-jar</id>
+							<phase>package</phase>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+							<inherited>true</inherited>
+							<configuration>
+								<includeDependencySources>true</includeDependencySources>
+								<additionalJOption>-Xdoclint:none</additionalJOption>
+								<additionalJOption>-Xdoclint:-missing</additionalJOption>
+								<doclint>none,-missing</doclint>
+								<quiet>true</quiet>
+							</configuration>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<inherited>true</inherited>
@@ -239,21 +253,6 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
 Reduced warnings during build process, specifically around the javadoc generation process by:
 - -none: To eliminate all warnings: JDK8+
 - additionalparam: <=Maven 2.9 (removed as mvn 3+ used)
 - additionalJOption: => Maven 3.0
 - doclint: maven-javadoc-plugin 3.0.0+

Also cleaned up the POMs a bit

Fixes issue #444 

Kindly review.