### PR TITLE
Initial move of the printFailedStartup method

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
@@ -78,7 +78,7 @@ public class AndHowCore implements StaticPropertyConfigurationInternal, Validate
 				"Since it is the framework itself that is misconfigured, no attempt was made to load values. " +
 				"See System.err, out or the log files for more details.",
 					problems);
-			printFailedStartupDetails(afe);
+			InternalUtil.printFailedStartupDetails(staticConfig, loaders, afe, LOG.getErrStream());
 			throw afe;
 		}
 		
@@ -90,7 +90,7 @@ public class AndHowCore implements StaticPropertyConfigurationInternal, Validate
 
 		if (problems.size() > 0) {
 			AppFatalException afe = AndHowUtil.buildFatalException(problems);
-			printFailedStartupDetails(afe);
+			InternalUtil.printFailedStartupDetails(staticConfig, loaders, afe, LOG.getErrStream());
 			throw afe;
 		}
 		
@@ -113,31 +113,6 @@ public class AndHowCore implements StaticPropertyConfigurationInternal, Validate
 		if (getValue(Options.CREATE_SAMPLES)) {
 			ReportGenerator.printConfigSamples(staticConfig, loaders, false);
 		}
-	}
-	
-	/**
-	 * Prints failed startup details to System.err
-	 * 
-	 * @param afe 
-	 */
-	private void printFailedStartupDetails(AppFatalException afe) {
-		
-		File sampleDir = ReportGenerator.printConfigSamples(staticConfig, loaders, true);
-		String sampleDirStr = (sampleDir != null)?sampleDir.getAbsolutePath():"";
-		afe.setSampleDirectory(sampleDirStr);
-		
-		ByteArrayOutputStream os = new ByteArrayOutputStream();
-		PrintStream ps = new PrintStream(os);
-		ReportGenerator.printProblems(ps, afe, staticConfig);
-		
-		try {
-			String message = os.toString("UTF8");
-			//Add separator prefix to prevent log prefixes from indenting 1st line
-			System.err.println(System.lineSeparator() + message);
-		} catch (UnsupportedEncodingException ex) {
-			ReportGenerator.printProblems(System.err, afe, staticConfig);	//shouldn't happen	
-		}
-		
 	}
 	
 	@Override

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/internal/InternalUtil.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/internal/InternalUtil.java
@@ -1,0 +1,50 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.yarnandtail.andhow.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import org.yarnandtail.andhow.api.AppFatalException;
+import org.yarnandtail.andhow.api.Loader;
+
+/**
+ *
+ * @author ericevermanpersonal
+ */
+public class InternalUtil {
+
+	/**
+	 * Prints details on a failed startup to a PrintStream.
+	 * 
+	 * @param staticConfig The current configuration for AndHow
+	 * @param loaders Loaders in use by AndHow - each may print a config sample
+	 * @param afe The fatal error that caused start to fail
+	 * @param out The PrintStream to write to
+	 */
+	public static void printFailedStartupDetails(StaticPropertyConfigurationInternal staticConfig,
+			List<Loader> loaders, AppFatalException afe, PrintStream out) {
+		
+		File sampleDir = ReportGenerator.printConfigSamples(staticConfig, loaders, true);
+		String sampleDirStr = (sampleDir != null)?sampleDir.getAbsolutePath():"";
+		afe.setSampleDirectory(sampleDirStr);
+		
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		PrintStream ps = new PrintStream(os);
+		ReportGenerator.printProblems(ps, afe, staticConfig);
+		
+		try {
+			String message = os.toString("UTF8");
+			//Add separator prefix to prevent log prefixes from indenting 1st line
+			out.println(System.lineSeparator() + message);
+		} catch (UnsupportedEncodingException ex) {
+			ReportGenerator.printProblems(System.err, afe, staticConfig);	//shouldn't happen	
+		}
+		
+	}
+}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/util/AndHowLog.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/util/AndHowLog.java
@@ -1,5 +1,6 @@
 package org.yarnandtail.andhow.util;
 
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.logging.*;
 import java.util.logging.Logger;
@@ -124,6 +125,40 @@ public class AndHowLog {
 		} else {
 			baseLogger.setLevel(null);
 		}
+	}
+	
+	/**
+	 * Returns the PrintStream used for error level logging (java.util.logging SEVERE level).
+	 * 
+	 * This is a 'best effort' method.  It assumes that this log has an
+	 * AndHowLogHandler and returns the err stream associated with it.  If some
+	 * one has done something weird, its possible to delete the handler, in
+	 * which case you will get the default System.err.
+	 * 
+	 * @return 
+	 */
+	public PrintStream getErrStream() {
+		AndHowLogHandler handler = (AndHowLogHandler) 
+				Arrays.asList(baseLogger.getHandlers()).stream().filter(h -> h instanceof AndHowLogHandler)
+						.findAny().orElse(DEFAULT_HANDLER);
+		return handler.getErrStream();
+	}
+	
+	/**
+	 * Returns the PrintStream used for non-error level logging (java.util.logging WARNING and lower).
+	 * 
+	 * This is a 'best effort' method.  It assumes that this log has an
+	 * AndHowLogHandler and returns the non-err stream associated with it.  If some
+	 * one has done something weird, its possible to delete the handler, in
+	 * which case you will get the default System.out.
+	 * 
+	 * @return 
+	 */
+	public PrintStream getNonErrStream() {
+		AndHowLogHandler handler = (AndHowLogHandler) 
+				Arrays.asList(baseLogger.getHandlers()).stream().filter(h -> h instanceof AndHowLogHandler)
+						.findAny().orElse(DEFAULT_HANDLER);
+		return handler.getNonErrStream();
 	}
 
 	//


### PR DESCRIPTION
language: java

jdk:

  - oraclejdk8

  - openjdk8

branches:

  except:

  - logo_submission

  

script: "mvn cobertura:cobertura"



after_success:

  - bash <(curl -s https://codecov.io/bash)