### PR TITLE
Adding Javadocs to org.yarnandtail.andhow.valuetype

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/BolType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/BolType.java
@@ -17,11 +17,20 @@ public class BolType extends BaseValueType<Boolean> {
 	private BolType() {
 		super(Boolean.class);
 	}
-	
+
+    /**
+     * @deprecated since 0.4.1. Use {@link #instance()} instead
+     *
+     * @return An instance of the {@link #BolType()}
+     */
+	@Deprecated()
 	public static BolType get() {
-		return instance;
+		return instance();
 	}
-	
+
+    /**
+     * @return An instance of the {@link #BolType()}
+     */
 	public static BolType instance() {
 		return instance;
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/DblType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/DblType.java
@@ -17,11 +17,20 @@ public class DblType extends BaseValueType<Double> {
 	private DblType() {
 		super(Double.class);
 	}
-	
+
+    /**
+     * @deprecated since 0.4.1. Use {@link #instance()} instead
+     *
+     * @return An instance of the {@link #DblType()}
+     */
+	@Deprecated()
 	public static DblType get() {
-		return instance;
+		return instance();
 	}
-	
+
+    /**
+     * @return An instance of the {@link #DblType()}
+     */
 	public static DblType instance() {
 		return instance;
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/FlagType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/FlagType.java
@@ -17,11 +17,20 @@ public class FlagType extends BaseValueType<Boolean> {
 	private FlagType() {
 		super(Boolean.class);
 	}
-	
+
+    /**
+     * @deprecated since 0.4.1. Use {@link #instance()} instead
+     *
+     * @return An instance of the {@link #FlagType()}
+     */
+	@Deprecated()
 	public static FlagType get() {
-		return instance;
+		return instance();
 	}
-	
+
+    /**
+     * @return An instance of the {@link #FlagType()}
+     */
 	public static FlagType instance() {
 		return instance;
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/IntType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/IntType.java
@@ -17,11 +17,20 @@ public class IntType extends BaseValueType<Integer> {
 	private IntType() {
 		super(Integer.class);
 	}
-	
+
+    /**
+     * @deprecated since 0.4.1. Use {@link #instance()} instead
+     *
+     * @return An instance of the {@link #IntType()}
+     */
+	@Deprecated()
 	public static IntType get() {
-		return instance;
+		return instance();
 	}
-	
+
+    /**
+     * @return An instance of the {@link #IntType()}
+     */
 	public static IntType instance() {
 		return instance;
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LngType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LngType.java
@@ -17,11 +17,20 @@ public class LngType extends BaseValueType<Long> {
 	private LngType() {
 		super(Long.class);
 	}
-	
+
+    /**
+     * @deprecated since 0.4.1. Use {@link #instance()} instead
+     *
+     * @return An instance of the {@link #LngType()}
+     */
+	@Deprecated()
 	public static LngType get() {
-		return instance;
+		return instance();
 	}
-	
+
+    /**
+     * @return An instance of the {@link #LngType()}
+     */
 	public static LngType instance() {
 		return instance;
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LocalDateTimeType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LocalDateTimeType.java
@@ -23,11 +23,20 @@ public class LocalDateTimeType extends BaseValueType<LocalDateTime> {
 	private LocalDateTimeType() {
 		super(LocalDateTime.class);
 	}
-	
+
+	/**
+	 * @deprecated since 0.4.1. Use {@link #instance()} instead
+	 *
+	 * @return An instance of the {@link #LocalDateTimeType()}
+	 */
+	@Deprecated
 	public static LocalDateTimeType get() {
-		return instance;
+		return instance();
 	}
-	
+
+	/**
+	 * @return An instance of the {@link #LocalDateTimeType()}
+	 */
 	public static LocalDateTimeType instance() {
 		return instance;
 	}
@@ -45,9 +54,9 @@ public class LocalDateTimeType extends BaseValueType<LocalDateTime> {
 	 * <li><code>2011-12-03T00:15:30</code> - The first hour is hour zero
 	 * <li><code>2011-12-03T23:00:00</code> - The last hour is hour 23
 	 * </ul>
-	 * @param sourceValue
-	 * @return
-	 * @throws ParsingException 
+	 * @param sourceValue The @{@link String} value to be parsed into a @{@link LocalDateTime}
+	 * @return A valid @{@link LocalDateTime}
+	 * @throws ParsingException If the @{@link String} can't be parsed into a @{@link LocalDateTime}
 	 */
 	@Override
 	public LocalDateTime parse(String sourceValue) throws ParsingException {

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/StrType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/StrType.java
@@ -17,7 +17,10 @@ public class StrType extends BaseValueType<String> {
 	private StrType() {
 		super(String.class);
 	}
-	
+
+	/**
+	 * @return An instance of the {@link #StrType()}
+	 */
 	public static StrType instance() {
 		return instance;
 	}


### PR DESCRIPTION
Steps towards adding javadocs & removing the static `get()` method 
 - `get()` calls `instance()` internally
 - Added (some) javadocs
 - Edited a couple of missing javadocs

References:
#466 directly
#455 indirectly
#465 partially