### PR TITLE
Removing the static get method from ValueType implementations

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LocalDateTimeType.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/valuetype/LocalDateTimeType.java
@@ -24,10 +24,6 @@ public class LocalDateTimeType extends BaseValueType<LocalDateTime> {
 		super(LocalDateTime.class);
 	}
 	
-	public static LocalDateTimeType get() {
-		return instance;
-	}
-	
 	public static LocalDateTimeType instance() {
 		return instance;
 	}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
@@ -26,7 +26,7 @@ public class AndHowReentrantTest extends AndHowCoreTestBase {
 				.group(AndHowReentrantTest_BadSample_1.class);
 		
 		try {
-			AndHow.instance(config);
+			AndHow.build(config);
 			fail("This should have blown up");
 		} catch (Throwable t) {
 			assertTrue(t.getCause() instanceof AppFatalException);
@@ -42,7 +42,7 @@ public class AndHowReentrantTest extends AndHowCoreTestBase {
 				.group(AndHowReentrantTest_OkSample_1.class);
 		
 
-			AndHow.instance(config);
+			AndHow.build(config);
 
 			assertEquals("onetwo", AndHowReentrantTest_OkSample_1.getSomeString());
 			assertEquals("one", AndHowReentrantTest_OkSample_1.STR_1.getValue());
@@ -56,7 +56,7 @@ public class AndHowReentrantTest extends AndHowCoreTestBase {
 				.group(AndHowReentrantTest_BadSample_2.class);
 		
 		try {
-			AndHow.instance(config);
+			AndHow.build(config);
 			fail("This should have blown up");
 		} catch (Throwable t) {
 			assertTrue(t.getCause() instanceof AppFatalException);


### PR DESCRIPTION
Removing the static get method from ValueType implementations

 - `get()` removed from `LocalDateTimeType`

I didn't find any more implementations, but if you can remember any more, @eeverman , please do call them out. 

References #465 