### PR TITLE
AnnotationProcessor now reports it supports all JDK versions

### DIFF
--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor.java
@@ -39,7 +39,6 @@ import org.yarnandtail.andhow.util.TextUtil;
  * Property containing classes.
  */
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AndHowCompileProcessor extends AbstractProcessor {
 	
 	private static final String INIT_CLASS_NAME = AndHowInit.class.getCanonicalName();
@@ -65,6 +64,13 @@ public class AndHowCompileProcessor extends AbstractProcessor {
 	public AndHowCompileProcessor() {
 		//used to ensure all metadata files have the same date
 		runDate = new GregorianCalendar();
+	}
+
+	@Override
+	public SourceVersion getSupportedSourceVersion() {
+		//Only scanning for declaration of AndHow Properties, so should
+		//be immune to most new language constructs.
+		return SourceVersion.latestSupported();
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<modules>
@@ -181,10 +183,11 @@
 							<rules>
 								<requireMavenVersion>
 									<!-- 3.2.2 req'ed for this bug fix: https://issues.apache.org/jira/browse/MNG-4565 -->
-									<version>3.2.2</version>
+									<version>(3.5,4.0)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>[1.8.0,1.9)</version>
+									<!-- 1.8 thru 15.  JDK 16 seems to have issues -->
+									<version>[1.8.0,16)</version>
 								</requireJavaVersion>
 							</rules>    
 						</configuration>


### PR DESCRIPTION
Also update the pom to:
* specify 1.8 as the source and target
* Specify a Java version as 1.8 to 15
* Specify a Maven version 3.5 up to 4.0

Fixes #492 