### PR TITLE
Now using the Generated annotation on generated files

### DIFF
--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/CompileUtil.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/CompileUtil.java
@@ -1,0 +1,70 @@
+package org.yarnandtail.andhow.compile;
+
+/**
+ * Utilities for the AndHow AnnotationProcessor.
+ */
+public class CompileUtil {
+
+	/**
+	 * Determine the correct 'Generated' annotation class name based on the current Java runtime.
+	 *
+	 * This method fetches the version of the current runtime via getMajorJavaVersion() and
+	 * uses that to call getGeneratedAnnotationClassName(int).
+	 *
+	 * @return A the fully qualified class name of the Generated annotation.
+	 */
+	public static String getGeneratedAnnotationClassName() {
+		return getGeneratedAnnotationClassName(getMajorJavaVersion(System.getProperty("java.version")));
+	}
+
+	/**
+	 * Determine the correct 'Generated' annotation class name based on the Java major version.
+	 * Java 8 uses the <code>@javax.annotation.Generated</code> annotation to mark a generated class.
+	 * Java 9 and beyond uses <code>@javax.annotation.processing.Generated</code>
+	 *
+	 * Both annotations are SOURCE level retention, so they are only present in the source code and no
+	 * record of them is compiled into the binary.  Thus, the determination of which one to use is
+	 * based only on the Java version used to compile, not the -source or -target settings.
+	 *
+	 * @param javaMajorVersion The Java version in integer form.  Use '8' for 1.8.
+	 * @return A the fully qualified class name of the Generated annotation.
+	 */
+	public static String getGeneratedAnnotationClassName(int javaMajorVersion) {
+		if (javaMajorVersion < 9) {
+			return "javax.annotation.Generated";
+		} else {
+			return "javax.annotation.processing.Generated";
+		}
+	}
+
+	/**
+	 * Determine the major version of the Java runtime based on a version string.
+	 *
+	 * All versions are integers, thus version `1.8` returns `8`.
+	 * Java 10 introduces the Runtime.version(), which would remove the need for this method,
+	 * however, at the moment the code is still Java 8 compatable.
+	 *
+	 * @param versionString As returned from SystemProperties.getProperty("java.version")
+	 * @return
+	 */
+	public static int getMajorJavaVersion(String versionString) {
+		String[] versionParts = versionString.split("[\\.\\-_]", 3);
+
+		try {
+			if ("1".equals(versionParts[0])) {
+				//Old style 1.x format
+				return Integer.parseInt(versionParts[1]);
+			} else {
+				return Integer.parseInt(versionParts[0]);
+			}
+
+		} catch (NumberFormatException e) {
+			throw new RuntimeException(
+					"AndHow couldn't parse '" + versionString + "' as a 'java.version' string in System.properties. " +
+							"Is this a non-standard JDK? ", e
+			);
+		}
+
+
+	}
+}

--- a/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGenerator.java
+++ b/andhow-annotation-processor/src/main/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGenerator.java
@@ -24,7 +24,8 @@ public class PropertyRegistrarClassGenerator {
 	 * Create a new instance w all info needed to generateSource a PropertyRegistrar file.
 	 * 
 	 * @param compUnit CompileUnit instance w/ all needed class and property info
-	 * @param generatingClass The class (likely an AnnotationProcessor) that will be annotated as the generator
+	 * @param generatingClass The class of our AnnotationProcessor to be listed as the generator in the
+	 *                        Generated annotation.
 	 * @param runDate  The Calendar date-time of the run, used for annotation.
 	 *		Passed in so all generated files can have the same timestamp.
 	 */
@@ -42,6 +43,7 @@ public class PropertyRegistrarClassGenerator {
 	public String getTemplate() throws Exception {
 		return IOUtil.getUTF8ResourceAsString(getTemplatePath());
 	}
+
 	
 	public String generateSource() throws Exception {
 
@@ -50,11 +52,14 @@ public class PropertyRegistrarClassGenerator {
 
 		String source = String.format(template,
 				buildPackageString(),
-				compUnit.getRootCanonicalName(), compUnit.getRootSimpleName(),
+				compUnit.getRootCanonicalName(),
+				compUnit.getRootSimpleName(),
 				buildGeneratedClassSimpleName(),
 				PropertyRegistrar.class.getCanonicalName(),
-				generatingClass.getCanonicalName(), buildRunDateString(),
-				buildRegistrationAddsString()
+				generatingClass.getCanonicalName(),
+				buildRunDateString(),
+				buildRegistrationAddsString(),
+				CompileUtil.getGeneratedAnnotationClassName()
 		);
 		
 		return source;

--- a/andhow-annotation-processor/src/main/resources/org/yarnandtail/andhow/compile/PropertyRegistrarClassGenerator_Template.txt
+++ b/andhow-annotation-processor/src/main/resources/org/yarnandtail/andhow/compile/PropertyRegistrarClassGenerator_Template.txt
@@ -4,12 +4,15 @@ import org.yarnandtail.andhow.service.AbstractPropertyRegistrar;
 import org.yarnandtail.andhow.service.PropertyRegistrationList;
 
 /*
-Java9 places 'Generated' in a module that needs to be separate included in a build
-or brought in as a dependency.  As a result, just using a comment instead.
-@javax.annotation.Generated(
+AndHow generated class that is discovered via the Service Provider API to
+register a proxied class as having AndHow properties.  These properties
+can then be auto-discovered and assigned values at startup.
+See:  https://github.com/eeverman/andhow
+*/
+@%9$s(
 	value="%6$s",
 	date="%7$s",
-	comments="Proxy for %2$s registered as a service provider in META-INF/services/%5$s") */
+	comments="Proxy for %2$s registered as a service provider in META-INF/services/%5$s")
 public class %4$s extends AbstractPropertyRegistrar {
 
 	@Override

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUtilTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUtilTest.java
@@ -1,0 +1,47 @@
+package org.yarnandtail.andhow.compile;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CompileUtilTest {
+
+	@Test
+	public void getGeneratedAnnotationClassNameTest() {
+		assertEquals("javax.annotation.Generated", CompileUtil.getGeneratedAnnotationClassName(8));
+		assertEquals("javax.annotation.processing.Generated", CompileUtil.getGeneratedAnnotationClassName(9));
+	}
+
+	@Test
+	public void getMajorJavaVersionHappyTest() {
+
+		assertEquals(8, CompileUtil.getMajorJavaVersion("1.8"));
+		assertEquals(8, CompileUtil.getMajorJavaVersion("1.8.434-be"));
+		assertEquals(8, CompileUtil.getMajorJavaVersion("1.8.0_152"));
+
+		assertEquals(9, CompileUtil.getMajorJavaVersion("9"));
+		assertEquals(9, CompileUtil.getMajorJavaVersion("9.0.1"));
+
+		//Weird stuff still ok
+		assertEquals(9, CompileUtil.getMajorJavaVersion("9-prerelease"));
+		assertEquals(9, CompileUtil.getMajorJavaVersion("9_prerelease"));
+
+		assertEquals(11, CompileUtil.getMajorJavaVersion("11"));
+		assertEquals(11, CompileUtil.getMajorJavaVersion("11.0"));
+		assertEquals(11, CompileUtil.getMajorJavaVersion("11.1"));
+		assertEquals(11, CompileUtil.getMajorJavaVersion("11.0.1"));
+		assertEquals(11, CompileUtil.getMajorJavaVersion("11.1-b53"));
+	}
+
+	@Test
+	public void getMajorJavaVersionExceptionTest() {
+
+		try {
+			CompileUtil.getMajorJavaVersion("WeirdVersion");
+			fail("This should have thrown an exception");
+		} catch (Exception e) {
+			//Expected
+		}
+
+	}
+}

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
@@ -143,7 +143,7 @@ public class PropertyRegistrarClassGeneratorTest {
 		assertEquals("list.add(\"" + PROP1_NAME + "\", \"" + INNER1_SIMP_NAME + "\", \"" + INNER2_SIMP_NAME + "\");", eachAdds[3]);
 		assertEquals("list.add(\"" + PROP2_NAME + "\");", eachAdds[4]);	//No inner path b/c in inherits from above
 	}
-	
+
 	/**
 	 * Basic gross test that the generated source is compilable
 	 */
@@ -159,6 +159,17 @@ public class PropertyRegistrarClassGeneratorTest {
 						.compile(JavaFileObjects.forSourceString(gen.buildGeneratedClassFullName(), sourceStr));
 		
 		assertThat(compilation).succeeded();
+
+		//Check the source file
+
+		//This method is separately tested, so lets trust it works correctly
+		int javaVersion = CompileUtil.getMajorJavaVersion(System.getProperty("java.version"));
+
+		if (javaVersion < 9) {
+			assertTrue(sourceStr.contains("@javax.annotation.Generated("));
+		} else {
+			assertTrue(sourceStr.contains("@javax.annotation.processing.Generated("));
+		}
 
 	}
 	


### PR DESCRIPTION
Fixes Issue #491 
Actually, its doesn't really fix the issue (there are still warnings in IntelliJ), but it tries the intended approach and the Generated annotation should be used anyway.

It sounds like the warnings are really an IntelliJ bug:
https://youtrack.jetbrains.com/issue/IDEA-159676