### PR TITLE
Issue501 update junit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ release.properties
 #IntelliJ Project directory
 .idea/
 **.iml
+.java-version

--- a/andhow-annotation-processor/pom.xml
+++ b/andhow-annotation-processor/pom.xml
@@ -39,10 +39,6 @@
 		
 		<!-- All dependencies are test dependencies only -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.google.testing.compile</groupId>
 			<artifactId>compile-testing</artifactId>
 		</dependency>

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileExceptionTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileExceptionTest.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Before;
 
 /**
  *

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileExceptionTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileExceptionTest.java
@@ -2,8 +2,8 @@ package org.yarnandtail.andhow.compile;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessorTestBase.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessorTestBase.java
@@ -6,7 +6,7 @@ import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.ToolProvider;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.yarnandtail.andhow.util.IOUtil;
 import org.yarnandtail.compile.MemoryFileManager;
 import org.yarnandtail.compile.TestClassLoader;
@@ -31,7 +31,7 @@ public class AndHowCompileProcessorTestBase {
 	
 	Set<TestSource> sources;	//New set of source files to compile
 	
-	@Before
+	@BeforeEach
 	public void setupTest() {
 		compiler = ToolProvider.getSystemJavaCompiler();
 		manager = new MemoryFileManager(compiler);

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_InitTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_InitTest.java
@@ -6,10 +6,10 @@ import java.nio.charset.Charset;
 import java.util.*;
 import javax.tools.*;
 import javax.tools.Diagnostic.Kind;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.util.IOUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A lot of this code was borrowed from here:
@@ -48,8 +48,11 @@ public class AndHowCompileProcessor_InitTest extends AndHowCompileProcessorTestB
 		String prodInitSvs = IOUtil.toString(loader.getResourceAsStream(INIT_SVS_PATH), Charset.forName("UTF-8"));
    		String testInitSvs = IOUtil.toString(loader.getResourceAsStream(TEST_INIT_SVS_PATH), Charset.forName("UTF-8"));
      
-		assertEquals("Should be no warn/errors", 0, diagnostics.getDiagnostics().stream().filter(
-				d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)).count());
+		assertEquals(0,
+				diagnostics.getDiagnostics().stream().filter(
+						d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)
+				).count(),
+				"Should be no warn/errors");
 
 		//
 		//Test the initiation files
@@ -75,8 +78,11 @@ public class AndHowCompileProcessor_InitTest extends AndHowCompileProcessorTestB
         
 		String prodInitSvs = IOUtil.toString(loader.getResourceAsStream(INIT_SVS_PATH), Charset.forName("UTF-8"));     
 
-		assertEquals("Should be no warn/errors", 0, diagnostics.getDiagnostics().stream().filter(
-				d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)).count());
+		assertEquals(0,
+				diagnostics.getDiagnostics().stream().filter(
+						d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)
+				).count(),
+				"Should be no warn/errors");
 
 		//
 		//Test the initiation files
@@ -99,8 +105,11 @@ public class AndHowCompileProcessor_InitTest extends AndHowCompileProcessorTestB
         
    		String testInitSvs = IOUtil.toString(loader.getResourceAsStream(TEST_INIT_SVS_PATH), Charset.forName("UTF-8"));
      
-		assertEquals("Should be no warn/errors", 0, diagnostics.getDiagnostics().stream().filter(
-				d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)).count());
+		assertEquals(0,
+				diagnostics.getDiagnostics().stream().filter(
+						d -> d.getKind().equals(Kind.ERROR) || d.getKind().equals(Kind.WARNING)
+				).count(),
+				"Should be no warn/errors");
 		
 
 		//

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_PropertyTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_PropertyTest.java
@@ -3,8 +3,8 @@ package org.yarnandtail.andhow.compile;
 import java.nio.charset.Charset;
 import java.util.*;
 import javax.tools.*;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.compile.CompileProblem.PropMissingFinal;
 import org.yarnandtail.andhow.compile.CompileProblem.PropMissingStatic;
 import org.yarnandtail.andhow.compile.CompileProblem.PropMissingStaticFinal;
@@ -41,8 +41,11 @@ public class AndHowCompileProcessor_PropertyTest extends AndHowCompileProcessorT
 		String genSvsFile = IOUtil.toString(
 				loader.getResourceAsStream(REGISTRAR_SVS_PATH), Charset.forName("UTF-8"));
         
-		assertEquals("Should be no warn/errors", 0, diagnostics.getDiagnostics().stream().filter(
-				d -> d.getKind().equals(Diagnostic.Kind.ERROR) || d.getKind().equals(Diagnostic.Kind.WARNING)).count());
+		assertEquals(0,
+				diagnostics.getDiagnostics().stream().filter(
+						d -> d.getKind().equals(Diagnostic.Kind.ERROR) || d.getKind().equals(Diagnostic.Kind.WARNING)
+				).count(),
+				"Should be no warn/errors");
 			
         assertNotNull(genClass);
 		
@@ -91,8 +94,11 @@ public class AndHowCompileProcessor_PropertyTest extends AndHowCompileProcessorT
 		String genSvsFile = IOUtil.toString(
 				loader.getResourceAsStream(REGISTRAR_SVS_PATH), Charset.forName("UTF-8"));
         
-		assertEquals("Should be no warn/errors", 0, diagnostics.getDiagnostics().stream().filter(
-				d -> d.getKind().equals(Diagnostic.Kind.ERROR) || d.getKind().equals(Diagnostic.Kind.WARNING)).count());
+		assertEquals(0,
+				diagnostics.getDiagnostics().stream().filter(
+						d -> d.getKind().equals(Diagnostic.Kind.ERROR) || d.getKind().equals(Diagnostic.Kind.WARNING)
+				).count(),
+				"Should be no warn/errors");
 
         assertNotNull(genClass);
 		

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileProblemTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileProblemTest.java
@@ -4,8 +4,8 @@ package org.yarnandtail.andhow.compile;
 
 import java.util.ArrayList;
 import javax.lang.model.element.Element;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.yarnandtail.andhow.compile.CompileProblem.*;
 import static org.mockito.Mockito.*;
 import org.yarnandtail.andhow.compile.AndHowCompileProcessor.CauseEffect;

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUnitTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUnitTest.java
@@ -1,9 +1,9 @@
 package org.yarnandtail.andhow.compile;
 
 import org.yarnandtail.andhow.service.PropertyRegistrationList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUtilTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/CompileUtilTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.compile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CompileUtilTest {
 

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
@@ -3,7 +3,7 @@ package org.yarnandtail.andhow.compile;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import java.util.*;
-import javax.tools.JavaFileObject;
+
 import org.junit.Test;
 import org.junit.Before;
 

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/PropertyRegistrarClassGeneratorTest.java
@@ -4,12 +4,12 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import java.util.*;
 
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -28,7 +28,7 @@ public class PropertyRegistrarClassGeneratorTest {
 	
 	private GregorianCalendar runDate;
 	
-	@Before
+	@BeforeEach
 	public void initEach() {
 		runDate = new GregorianCalendar();
 		//runDate.setTimeZone(TimeZone.getTimeZone(ZoneId.of("GMT-6")));

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/__PropertySample_PropertyRegistrationForClassTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/__PropertySample_PropertyRegistrationForClassTest.java
@@ -3,9 +3,9 @@ package org.yarnandtail.andhow.compile;
 import org.yarnandtail.andhow.service.PropertyRegistrar;
 import org.yarnandtail.andhow.service.PropertyRegistration;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/pom.xml
+++ b/andhow-core/pom.xml
@@ -14,11 +14,14 @@
 	</description>
 
 	<dependencies>
-		
 		<!-- All dependencies are test dependencies only -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowCoreTestBase.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowCoreTestBase.java
@@ -2,7 +2,11 @@ package org.yarnandtail.andhow;
 
 import java.util.Properties;
 import javax.naming.NamingException;
-import org.junit.*;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 
 /**
@@ -45,50 +49,50 @@ public class AndHowCoreTestBase {
 	 */
 	private static SimpleNamingContextBuilder builder;
 	
-	@BeforeClass
+	@BeforeAll
 	public static void killAndHowStateBeforeClass() {
 		AndHowCoreTestUtil.destroyAndHow();
 	}
 	
-	@BeforeClass
+	@BeforeAll
 	public static void storeSysPropsBeforeClass() {
 		beforeClassSystemProps = AndHowCoreTestUtil.clone(System.getProperties());
 	}
 	
-	@Before
+	@BeforeEach
 	public void killAndHowStateBeforeTest() {
 		AndHowCoreTestUtil.destroyAndHow();
 	}
 	
-	@Before
+	@BeforeEach
 	public void storeSysPropsBeforeTest() {
 		beforeTestSystemProps = AndHowCoreTestUtil.clone(System.getProperties());
 	}
 	
-	@After
+	@AfterEach
 	public void killAndHowStateAfterTest() {
 		AndHowCoreTestUtil.destroyAndHow();
 	}
 	
-	@After
+	@AfterEach
 	public void clearJNDIAfterTest() {
 		if (builder != null) {
 			builder.clear();
 		}
 	}
 	
-	@After
+	@AfterEach
 	public void restoreSysPropsAfterTest() {
 		System.setProperties(beforeTestSystemProps);
 	}
 	
 	
-	@AfterClass
+	@AfterAll
 	public static void killAndHowStateAfterClass() {
 		AndHowCoreTestUtil.destroyAndHow();
 	}
 	
-	@AfterClass
+	@AfterAll
 	public static void restoreSysPropsAfterClass() {
 		System.setProperties(beforeClassSystemProps);
 	}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
@@ -1,11 +1,11 @@
 package org.yarnandtail.andhow;
 
 
-import static org.junit.Assert.*;
-import org.junit.FixMethodOrder;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.TestMethodOrder;
 
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.MethodOrderer;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.ConstructionProblem;
 
@@ -16,7 +16,7 @@ import org.yarnandtail.andhow.internal.ConstructionProblem;
  * bleed over from one test to another. 
  * @author eeverman
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class AndHowReentrantTest extends AndHowCoreTestBase {
 	
 	

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -3,7 +3,9 @@ package org.yarnandtail.andhow;
 import java.io.File;
 import java.time.LocalDateTime;
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.api.Property;
 import org.yarnandtail.andhow.internal.*;
@@ -12,7 +14,7 @@ import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.FlagProp;
 import org.yarnandtail.andhow.property.StrProp;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test is a minimal unit teat because this class is not really testable
@@ -39,7 +41,7 @@ public class AndHowTest extends AndHowCoreTestBase {
 		FlagProp FLAG_NULL = FlagProp.builder().mustBeNonNull().build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		
 		configPtGroups.clear();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -1,10 +1,10 @@
 package org.yarnandtail.andhow;
 
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.RequirementProblem;
 import org.yarnandtail.andhow.load.KeyValuePairLoader;
@@ -21,7 +21,7 @@ public class AndHowUsageExampleTest extends AndHowCoreTestBase {
 	String[] cmdLineArgsWFullClassName = new String[0];
 
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		
 		cmdLineArgsWFullClassName = new String[] {

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.ConstructionProblem;
@@ -10,7 +10,7 @@ import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
@@ -2,18 +2,14 @@ package org.yarnandtail.andhow;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.*;
-
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.export.SysPropExporter;
-import org.yarnandtail.andhow.util.AndHowUtil;
 import org.yarnandtail.andhow.internal.ConstructionProblem;
-import org.yarnandtail.andhow.internal.NameAndProperty;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
-import org.yarnandtail.andhow.util.NameUtil;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/PropertyValueTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/PropertyValueTest.java
@@ -1,9 +1,10 @@
 package org.yarnandtail.andhow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.yarnandtail.andhow.api.ParsingException;
 import org.yarnandtail.andhow.property.StrProp;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.yarnandtail.andhow.SimpleParams.*;
 
 /**
@@ -140,9 +141,11 @@ public class PropertyValueTest {
 		assertEquals(SPV5.getValue(), "abc");
 	}
 	
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testConstructor() {
-		PropertyValue NULL_PROP = new PropertyValue((StrProp)null, null);
+		assertThrows(RuntimeException.class, () ->
+				new PropertyValue((StrProp)null, null)
+		);
 	}
 	
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigTest.java
@@ -4,7 +4,7 @@ package org.yarnandtail.andhow;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.StdConfig.StdConfigImpl;
 import org.yarnandtail.andhow.api.Loader;
 import org.yarnandtail.andhow.api.StandardLoader;
@@ -12,7 +12,7 @@ import org.yarnandtail.andhow.load.*;
 import org.yarnandtail.andhow.load.std.*;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/api/AppFatalExceptionTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/api/AppFatalExceptionTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.api;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AppFatalExceptionTest {
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/api/LoaderValuesTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/api/LoaderValuesTest.java
@@ -1,10 +1,10 @@
 package org.yarnandtail.andhow.api;
 
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.load.*;
 import java.util.*;
-import org.junit.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.yarnandtail.andhow.property.StrProp;
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/api/NameTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/api/NameTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.api;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/api/PropertyTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/api/PropertyTypeTest.java
@@ -1,9 +1,9 @@
 package org.yarnandtail.andhow.api;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PropertyTypeTest {
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/example/restclient/SampleRestClientAppTest.java
@@ -2,10 +2,10 @@ package org.yarnandtail.andhow.example.restclient;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
@@ -24,7 +24,7 @@ public class SampleRestClientAppTest extends AndHowCoreTestBase {
 	private static final String GROUP_PATH = "org.yarnandtail.andhow.example.restclient.SampleRestClientGroup";
 
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		
 		cmdLineArgs = new String[0];

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/ConstructionProblemTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/ConstructionProblemTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.AndHowInit;
 import java.util.ArrayList;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationImmutableTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationImmutableTest.java
@@ -4,9 +4,9 @@ package org.yarnandtail.andhow.internal;
 
 import org.yarnandtail.andhow.util.AndHowUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.StrProp;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationMutableTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationMutableTest.java
@@ -3,9 +3,9 @@ package org.yarnandtail.andhow.internal;
 
 import org.yarnandtail.andhow.util.AndHowUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.NamingStrategy;
 import org.yarnandtail.andhow.api.ProblemList;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/ValueMapWithContextMutableTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/ValueMapWithContextMutableTest.java
@@ -3,9 +3,9 @@ package org.yarnandtail.andhow.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.SimpleParams;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/KVPTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/KVPTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.load;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**
@@ -98,34 +98,46 @@ public class KVPTest {
 		
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadEmptyFlagName() throws Exception {
-		KVP.splitKVP("=value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadEmptyFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("=value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadSpaceOnlyFlagName() throws Exception {
-		KVP.splitKVP("  =value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadSpaceOnlyFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("  =value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadAllSpaceAndTabFlagName() throws Exception {
-		KVP.splitKVP("   \t =value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadAllSpaceAndTabFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("   \t =value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadAllWhitespaceAndNewLinesFlagName() throws Exception {
-		KVP.splitKVP("   \t\n\r\f = value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadAllWhitespaceAndNewLinesFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("   \t\n\r\f = value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadAllBackspaceFlagName() throws Exception {
-		KVP.splitKVP("\b =value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadAllBackspaceFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("\b =value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void splitKVPBadAllWhitespaceAndBackspaceFlagName() throws Exception {
-		KVP.splitKVP("   \b  =value", KeyValuePairLoader.KVP_DELIMITER);
+	@Test
+	public void splitKVPBadAllWhitespaceAndBackspaceFlagName() {
+		assertThrows(ParsingException.class, () ->
+			KVP.splitKVP("   \b  =value", KeyValuePairLoader.KVP_DELIMITER)
+		);
 	}
 	
 	@Test
@@ -145,9 +157,11 @@ public class KVPTest {
 		assertNull(kvp.getValue());
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void newKVPByNameOnlyBadEmptyName() throws Exception {
-		new KVP("  \t \r\n ");
+	@Test
+	public void newKVPByNameOnlyBadEmptyName() {
+		assertThrows(ParsingException.class, () ->
+			new KVP("  \t \r\n ")
+		);
 	}
 	
 	@Test
@@ -163,8 +177,10 @@ public class KVPTest {
 		assertNull(kvp.getValue());
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void newKVPByNameAndValueBadEmptyName() throws Exception {
-		new KVP("  \t \r\n ", "value");
+	@Test
+	public void newKVPByNameAndValueBadEmptyName(){
+		assertThrows(ParsingException.class, () ->
+			new KVP("  \t \r\n ", "value")
+		);
 	}
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/KeyValuePairLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/KeyValuePairLoaderTest.java
@@ -3,10 +3,10 @@ package org.yarnandtail.andhow.load;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.*;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
@@ -39,7 +39,7 @@ public class KeyValuePairLoaderTest {
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
 
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		appValuesBuilder = new ValidatedValuesWithContextMutable();
 		

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/LoaderExceptionTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/LoaderExceptionTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LoaderExceptionTest {
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderAppTest.java
@@ -2,9 +2,9 @@ package org.yarnandtail.andhow.load;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.api.Problem;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderUnitTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderUnitTest.java
@@ -2,10 +2,10 @@ package org.yarnandtail.andhow.load;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationMutable;
 import org.yarnandtail.andhow.internal.LoaderProblem;
@@ -41,7 +41,7 @@ public class PropFileOnClasspathLoaderUnitTest {
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		
 		appValuesBuilder = new ValidatedValuesWithContextMutable();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderAppTest.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.net.URL;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.ConstructionProblem.LoaderPropertyNotRegistered;
@@ -31,7 +31,7 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 	}
 	
 
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		
 		//copy a properties file to a temp location
@@ -42,7 +42,7 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 
 	}
 	
-	@After
+	@AfterEach
 	public void afterTest() {
 		if (tempPropertiesFile != null) {
 			tempPropertiesFile.delete();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderUnitTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderUnitTest.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationMutable;
 import org.yarnandtail.andhow.internal.LoaderProblem;
@@ -46,7 +46,7 @@ public class PropFileOnFilesystemLoaderUnitTest {
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		
 		appValuesBuilder = new ValidatedValuesWithContextMutable();
@@ -73,7 +73,7 @@ public class PropFileOnFilesystemLoaderUnitTest {
 
 	}
 	
-	@After
+	@AfterEach
 	public void afterTest() {
 		if (tempPropertiesFile != null) {
 			tempPropertiesFile.delete();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdEnvVarLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdEnvVarLoaderTest.java
@@ -1,14 +1,11 @@
 package org.yarnandtail.andhow.load.std;
 
-import org.yarnandtail.andhow.load.std.StdEnvVarLoader;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.util.AndHowUtil;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationMutable;
@@ -39,7 +36,7 @@ public class StdEnvVarLoaderTest {
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		
 		appValuesBuilder = new ValidatedValuesWithContextMutable();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
@@ -4,9 +4,9 @@ import org.yarnandtail.andhow.SimpleParams;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.*;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdSysPropLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdSysPropLoaderTest.java
@@ -1,12 +1,12 @@
 package org.yarnandtail.andhow.load.std;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.yarnandtail.andhow.util.AndHowUtil;
-import org.junit.After;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.*;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
@@ -35,7 +35,7 @@ public class StdSysPropLoaderTest {
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		
 		appValuesBuilder = new ValidatedValuesWithContextMutable();
@@ -55,7 +55,7 @@ public class StdSysPropLoaderTest {
 		
 	}
 	
-	@After
+	@AfterEach
 	public void post() throws Exception {
 		clearSysProps();
 	}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/name/CaseInsensitiveNamingTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/name/CaseInsensitiveNamingTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.name;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.PropertyNaming;
 import org.yarnandtail.andhow.property.StrProp;
 import org.yarnandtail.andhow.api.GroupProxy;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/BigDecPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/BigDecPropTest.java
@@ -1,6 +1,6 @@
 package org.yarnandtail.andhow.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.api.Problem;
@@ -10,7 +10,7 @@ import org.yarnandtail.andhow.internal.ValueProblem.InvalidValueProblem;
 
 import javax.naming.NamingException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/BolPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/BolPropTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.RequirementProblem;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBuilderBaseTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBuilderBaseTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.property;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.api.Name;
 import org.yarnandtail.andhow.valuetype.FlagType;
@@ -52,32 +52,40 @@ public class PropertyBuilderBaseTest {
 		assertTrue(kathy.isIn() && kathy.isOut());
 	}
 	
-	@Test(expected=AppFatalException.class)
+	@Test
 	public void testAliasesSlashCharactersNotAllowed() {
 		TestBuilder builder = new TestBuilder();
-		
-		builder.aliasInAndOut("a/path/looking/one");
+
+		assertThrows(AppFatalException.class, () ->
+			builder.aliasInAndOut("a/path/looking/one")
+		);
 	}
 	
-	@Test(expected=AppFatalException.class)
+	@Test
 	public void testAliasesQuoteCharactersNotAllowed() {
 		TestBuilder builder = new TestBuilder();
-		
-		builder.aliasInAndOut("\"NoQuotes\"");
+
+		assertThrows(AppFatalException.class, () ->
+			builder.aliasInAndOut("\"NoQuotes\"")
+		);
 	}
 	
-	@Test(expected=AppFatalException.class)
+	@Test
 	public void testAliasesSpaceCharactersNotAllowed() {
 		TestBuilder builder = new TestBuilder();
-		
-		builder.aliasInAndOut("  NoSpaces");
+
+		assertThrows(AppFatalException.class, () ->
+			builder.aliasInAndOut("  NoSpaces")
+		);
 	}
 	
-	@Test(expected=AppFatalException.class)
+	@Test
 	public void testAliasesNullNotAllowed() {
 		TestBuilder builder = new TestBuilder();
-		
-		builder.aliasInAndOut(null);
+
+		assertThrows(AppFatalException.class, () ->
+			builder.aliasInAndOut(null)
+		);
 	}
 	
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/QuotedSpacePreservingTrimmerTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/QuotedSpacePreservingTrimmerTest.java
@@ -2,8 +2,8 @@
  */
 package org.yarnandtail.andhow.property;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.yarnandtail.andhow.api.*;
 import org.yarnandtail.andhow.internal.ValueProblem;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/TrimToNullTrimmerTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/TrimToNullTrimmerTest.java
@@ -1,8 +1,8 @@
 package org.yarnandtail.andhow.property;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests TrimToNullTrimmer instances as they would be used in an app.

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
@@ -3,8 +3,9 @@
 package org.yarnandtail.andhow.sample;
 
 import java.io.UnsupportedEncodingException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import org.yarnandtail.andhow.api.GroupProxyMutable;
 import org.yarnandtail.andhow.internal.NameAndProperty;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationMutable;
@@ -12,8 +13,6 @@ import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
 import org.yarnandtail.andhow.util.TextUtil;
-
-import static org.junit.Assert.*;
 
 /**
  *
@@ -31,7 +30,7 @@ public class JndiLoaderSamplePrinterTest {
 				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		config = new StaticPropertyConfigurationMutable(new CaseInsensitiveNaming());
 		
@@ -42,8 +41,8 @@ public class JndiLoaderSamplePrinterTest {
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP1", Config.MY_PROP1));
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP2", Config.MY_PROP2));
 		
-		assertNull("Error adding property", config.addProperty(groupProxy1, Config.MY_PROP1));
-		assertNull("Error adding property", config.addProperty(groupProxy1, Config.MY_PROP2));
+		assertNull(config.addProperty(groupProxy1, Config.MY_PROP1));
+		assertNull(config.addProperty(groupProxy1, Config.MY_PROP2));
 
 	}
 	

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
@@ -3,8 +3,8 @@
 package org.yarnandtail.andhow.sample;
 
 import java.io.UnsupportedEncodingException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.GroupProxyMutable;
 import org.yarnandtail.andhow.internal.NameAndProperty;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationMutable;
@@ -13,7 +13,7 @@ import org.yarnandtail.andhow.property.IntProp;
 import org.yarnandtail.andhow.property.StrProp;
 import org.yarnandtail.andhow.util.TextUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -31,7 +31,7 @@ public class PropFileLoaderSamplePrinterTest {
 				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		config = new StaticPropertyConfigurationMutable(new CaseInsensitiveNaming());
 		
@@ -42,8 +42,8 @@ public class PropFileLoaderSamplePrinterTest {
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP1", Config.MY_PROP1));
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP2", Config.MY_PROP2));
 		
-		assertNull("Error adding property", config.addProperty(groupProxy1, Config.MY_PROP1));
-		assertNull("Error adding property", config.addProperty(groupProxy1, Config.MY_PROP2));
+		assertNull(config.addProperty(groupProxy1, Config.MY_PROP1));
+		assertNull(config.addProperty(groupProxy1, Config.MY_PROP2));
 
 	}
 	

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/TextLineTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/TextLineTest.java
@@ -2,10 +2,10 @@
  */
 package org.yarnandtail.andhow.sample;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.util.TextUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrarLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrarLoaderTest.java
@@ -2,12 +2,12 @@ package org.yarnandtail.andhow.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.yarnandtail.andhow.service.PropertyRegistrationList;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.GroupProxy;
 import org.yarnandtail.andhow.property.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrationListTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrationListTest.java
@@ -1,9 +1,8 @@
 package org.yarnandtail.andhow.service;
 
-import org.yarnandtail.andhow.service.PropertyRegistrationList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrationTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrationTest.java
@@ -2,11 +2,10 @@
  */
 package org.yarnandtail.andhow.service;
 
-import org.yarnandtail.andhow.service.PropertyRegistration;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/AndHowLogTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/AndHowLogTest.java
@@ -5,9 +5,12 @@ package org.yarnandtail.andhow.util;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.logging.Level;
-import org.junit.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -25,7 +28,7 @@ public class AndHowLogTest {
 	public AndHowLogTest() {
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		AndHowLogHandler handler = (AndHowLogHandler) log.getHandlers()[0];
@@ -41,7 +44,7 @@ public class AndHowLogTest {
 		handler.setNonErrStream(testNonErrPrintStream);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 
 		AndHowLogHandler handler = (AndHowLogHandler) log.getHandlers()[0];
@@ -71,13 +74,13 @@ public class AndHowLogTest {
 		String sampleMsg = "This is a fact you don't care about";
 
 		log.trace(sampleMsg);
-		assertEquals("trace is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "trace is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(Level.FINEST);
 		log.trace(sampleMsg);
 		assertTrue(testNonErrByteArray.toString().contains(sampleMsg));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		// Complete reset
 		tearDown();
@@ -89,8 +92,8 @@ public class AndHowLogTest {
 		log.setLevel(null);
 
 		log.trace(sampleMsg);
-		assertEquals("trace is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "trace is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		System.setProperty(AndHowLogTest.class.getCanonicalName() + ".level", Level.FINEST.getName());
 		log.setLevel(null);
@@ -104,13 +107,13 @@ public class AndHowLogTest {
 	@Test
 	public void testTrace_String_ObjectArr() {
 		log.trace("Some debug on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("trace is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "trace is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(Level.FINEST);
 		log.trace("Some debug on line {0}, message ''{1}''", "42", "Bee Boo");
 		assertTrue(testNonErrByteArray.toString().contains("Some debug on line 42, message 'Bee Boo'"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		// Complete reset
 		tearDown();
@@ -122,8 +125,8 @@ public class AndHowLogTest {
 		log.setLevel(null);
 
 		log.trace("Some debug on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("trace is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "trace is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		System.setProperty(AndHowLogTest.class.getCanonicalName() + ".level", Level.FINEST.getName());
 		log.setLevel(null);
@@ -138,13 +141,13 @@ public class AndHowLogTest {
 	public void testTrace_String_Throwable() {
 		Exception ex = new Exception("ALERT!");
 		log.trace("It is nothing serious", ex);
-		assertEquals("trace is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "trace is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 		log.setLevel(Level.FINEST);
 		log.trace("It is nothing serious", ex);
 		assertTrue(testNonErrByteArray.toString().contains("It is nothing serious"));
 		assertTrue(testNonErrByteArray.toString().contains("ALERT!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	}
 
 	/**
@@ -153,13 +156,13 @@ public class AndHowLogTest {
 	@Test
 	public void testDebug_String() {
 		log.debug("Hello!!!!");
-		assertEquals("debug is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "debug is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(Level.FINE);
 		log.debug("Hello!!!!");
 		assertTrue(testNonErrByteArray.toString().contains("Hello!!!!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		// Complete reset
 		tearDown();
@@ -172,13 +175,13 @@ public class AndHowLogTest {
 	@Test
 	public void testDebug_String_ObjectArr() {
 		log.debug("Some debug on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("debug is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "debug is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(Level.FINE);
 		log.debug("Some debug on line {0}, message ''{1}''", "42", "Bee Boo");
 		assertTrue(testNonErrByteArray.toString().contains("Some debug on line 42, message 'Bee Boo'"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 		// Complete reset
 		tearDown();
 		setUp();
@@ -191,14 +194,14 @@ public class AndHowLogTest {
 	public void testDebug_String_Throwable() {
 		Exception ex = new Exception("ALERT!");
 		log.debug("It is nothing serious", ex);
-		assertEquals("debug is off by default", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "debug is off by default");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(Level.FINE);
 		log.debug("It is nothing serious", ex);
 		assertTrue(testNonErrByteArray.toString().contains("It is nothing serious"));
 		assertTrue(testNonErrByteArray.toString().contains("ALERT!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 		// Complete reset
 		tearDown();
 		setUp();
@@ -211,13 +214,13 @@ public class AndHowLogTest {
 	public void testInfo_String() {
 		log.setLevel(Level.OFF);
 		log.info("Hello!!!!");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(null);
 		log.info("Hello!!!!");
 		assertTrue(testNonErrByteArray.toString().contains("Hello!!!!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	}
 
 	/**
@@ -227,13 +230,13 @@ public class AndHowLogTest {
 	public void testInfo_String_ObjectArr() {
 		log.setLevel(Level.OFF);
 		log.info("Some info on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(null);
 		log.info("Some info on line {0}, message ''{1}''", "42", "Bee Boo");
 		assertTrue(testNonErrByteArray.toString().contains("Some info on line 42, message 'Bee Boo'"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	}
 
 	/**
@@ -244,14 +247,14 @@ public class AndHowLogTest {
 		Exception ex = new Exception("ALERT!");
 		log.setLevel(Level.OFF);
 		log.info("It is nothing serious", ex);
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 		log.setLevel(null);
 		log.info("It is nothing serious", ex);
 		assertTrue(testNonErrByteArray.toString().contains("It is nothing serious"));
 		assertTrue(testNonErrByteArray.toString().contains("ALERT!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	}
 
 	/**
@@ -261,13 +264,13 @@ public class AndHowLogTest {
 	public void testWarn_String() {
 		log.setLevel(Level.OFF);
 		log.warn("Hello!!!!");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	
 		log.setLevel(null);
 		log.warn("Hello!!!!");
 		assertTrue(testNonErrByteArray.toString().contains("Hello!!!!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 	}
 
@@ -278,13 +281,13 @@ public class AndHowLogTest {
 	public void testWarn_String_ObjectArr() {
 		log.setLevel(Level.OFF);
 		log.warn("Some info on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	
 		log.setLevel(null);
 		log.warn("Some info on line {0}, message ''{1}''", "42", "Bee Boo");
 		assertTrue(testNonErrByteArray.toString().contains("Some info on line 42, message 'Bee Boo'"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 	}
 
@@ -297,15 +300,15 @@ public class AndHowLogTest {
 
 		log.setLevel(Level.OFF);
 		log.warn("It cane be serious", ex);
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	
 		log.setLevel(null);
 		
 		log.warn("It cane be serious", ex);
 		assertTrue(testNonErrByteArray.toString().contains("It cane be serious"));
 		assertTrue(testNonErrByteArray.toString().contains("ALERT!"));
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 
 	}
 
@@ -316,13 +319,13 @@ public class AndHowLogTest {
 	public void testError_String() {
 		log.setLevel(Level.OFF);
 		log.error("Oh-No!!!!");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	
 		log.setLevel(null);
 		log.error("Oh-No!!!!");
 		assertTrue(testErrByteArray.toString().contains("Oh-No!!!!"));
-		assertEquals("nonErr stream should be empty", 0, testNonErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "nonErr stream should be empty");
 	}
 
 	/**
@@ -332,13 +335,13 @@ public class AndHowLogTest {
 	public void testError_String_ObjectArr() {
 		log.setLevel(Level.OFF);
 		log.error("Big err on line {0}, message ''{1}''", "42", "Bee Boo");
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 	
 		log.setLevel(null);
 		log.error("Big err on line {0}, message ''{1}''", "42", "Bee Boo");
 		assertTrue(testErrByteArray.toString().contains("Big err on line 42, message 'Bee Boo'"));
-		assertEquals("nonErr stream should be empty", 0, testNonErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "nonErr stream should be empty");
 	}
 
 	/**
@@ -349,14 +352,14 @@ public class AndHowLogTest {
 		log.setLevel(Level.OFF);
 		Exception ex = new Exception("ALERT!");
 		log.error("Big Error!", ex);
-		assertEquals("Logging is off now", 0, testNonErrByteArray.toString().length());
-		assertEquals("err stream should be empty", 0, testErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "Logging is off now");
+		assertEquals(0, testErrByteArray.toString().length(), "err stream should be empty");
 		
 		log.setLevel(null);
 		log.error("Big Error!", ex);
 		assertTrue(testErrByteArray.toString().contains("Big Error!"));
 		assertTrue(testErrByteArray.toString().contains("ALERT!"));
-		assertEquals("nonErr stream should be empty", 0, testNonErrByteArray.toString().length());
+		assertEquals(0, testNonErrByteArray.toString().length(), "nonErr stream should be empty");
 	}
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/AndHowUtilTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/AndHowUtilTest.java
@@ -2,13 +2,12 @@
  */
 package org.yarnandtail.andhow.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/IOUtilTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/IOUtilTest.java
@@ -2,8 +2,8 @@
  */
 package org.yarnandtail.andhow.util;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/NameUtilTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/NameUtilTest.java
@@ -1,12 +1,11 @@
 package org.yarnandtail.andhow.util;
 
-import org.yarnandtail.andhow.util.NameUtil;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Naming support for Properties.

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/StackLocatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/StackLocatorTest.java
@@ -1,8 +1,7 @@
 package org.yarnandtail.andhow.util;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is testing production code from Log4J, so this is really just characterization.

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/util/TextUtilTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/util/TextUtilTest.java
@@ -4,9 +4,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yarnandtail.andhow.api.ParsingException;
 
 /**
  *
@@ -17,7 +18,7 @@ public class TextUtilTest {
 	PrintStream ps;
 	private static String FIND_INSTANCE_STRING_BROWNFOX = "The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog";
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		baos = new ByteArrayOutputStream();
 		ps = new PrintStream(baos) {
@@ -54,9 +55,11 @@ public class TextUtilTest {
 		assertEquals("abcXXXdef[[NULL]]xyz", TextUtil.format("abc{}def{}xyz", "XXX", null, null));
 	}
 	
-	@Test(expected = ArrayIndexOutOfBoundsException.class)
+	@Test
 	public void testFormatException() {
-		assertEquals("abcXXXxyz", TextUtil.format("abc{}xyz{}", "XXX"));
+		assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+			assertEquals("abcXXXxyz", TextUtil.format("abc{}xyz{}", "XXX"))
+		);
 	}
 
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/BigDecValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/BigDecValidatorTest.java
@@ -1,12 +1,12 @@
 package org.yarnandtail.andhow.valid;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BigDecValidatorTest {
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/DblValidatorTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valid;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/IntValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/IntValidatorTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valid;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/LngValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/LngValidatorTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valid;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/LocalDateTimeValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/LocalDateTimeValidatorTest.java
@@ -2,8 +2,8 @@ package org.yarnandtail.andhow.valid;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -20,12 +20,12 @@ public class LocalDateTimeValidatorTest {
 		LocalDateTimeValidator.Before instance = new LocalDateTimeValidator.Before(DEC_03_2007_AT_5PM);
 		assertTrue(instance.isSpecificationValid());
 		
-		assertTrue("One nano second before", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)));
-		assertTrue("One day second before", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.DAYS)));
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)), "One nano second before");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.DAYS)), "One day second before");
 		
-		assertFalse("Same date should not be valid", instance.isValid(DEC_03_2007_AT_5PM));
-		assertFalse("One nano after should not be valid", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)));
-		assertFalse("Null should not be valid", instance.isValid(null));
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM), "Same date should not be valid");
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)), "One nano after should not be valid");
+		assertFalse(instance.isValid(null), "Null should not be valid");
 
 		assertEquals(INVALID_SPECIFICATION_MESSAGE, instance.getInvalidSpecificationMessage());
 
@@ -37,12 +37,12 @@ public class LocalDateTimeValidatorTest {
 		LocalDateTimeValidator.SameTimeOrBefore instance = new LocalDateTimeValidator.SameTimeOrBefore(DEC_03_2007_AT_5PM);
 		assertTrue(instance.isSpecificationValid());
 		
-		assertTrue("One nano second before", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)));
-		assertTrue("One day second before", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.DAYS)));
-		assertTrue("Same date should be valid", instance.isValid(DEC_03_2007_AT_5PM));
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)), "One nano second before");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.DAYS)), "One day second before");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM), "Same date should be valid");
 		
-		assertFalse("One nano after should not be valid", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)));
-		assertFalse("Null should not be valid", instance.isValid(null));
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)), "One nano after should not be valid");
+		assertFalse(instance.isValid(null), "Null should not be valid");
 
 		assertEquals(INVALID_SPECIFICATION_MESSAGE, instance.getInvalidSpecificationMessage());
 
@@ -54,12 +54,12 @@ public class LocalDateTimeValidatorTest {
 		LocalDateTimeValidator.After instance = new LocalDateTimeValidator.After(DEC_03_2007_AT_5PM);
 		assertTrue(instance.isSpecificationValid());
 		
-		assertTrue("One nano second after", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)));
-		assertTrue("One day second before", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.DAYS)));
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)), "One nano second after");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.DAYS)), "One day second before");
 		
-		assertFalse("Same date should not be valid", instance.isValid(DEC_03_2007_AT_5PM));
-		assertFalse("One nano before should not be valid", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)));
-		assertFalse("Null should not be valid", instance.isValid(null));
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM), "Same date should not be valid");
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)), "One nano before should not be valid");
+		assertFalse(instance.isValid(null), "Null should not be valid");
 
 		assertEquals(INVALID_SPECIFICATION_MESSAGE, instance.getInvalidSpecificationMessage());
 
@@ -71,12 +71,12 @@ public class LocalDateTimeValidatorTest {
 		LocalDateTimeValidator.SameTimeOrAfter instance = new LocalDateTimeValidator.SameTimeOrAfter(DEC_03_2007_AT_5PM);
 		assertTrue(instance.isSpecificationValid());
 		
-		assertTrue("One nano second after", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)));
-		assertTrue("One day second after", instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.DAYS)));
-		assertTrue("Same date should be valid", instance.isValid(DEC_03_2007_AT_5PM));
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.NANOS)), "One nano second after");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM.plus(1, ChronoUnit.DAYS)), "One day second after");
+		assertTrue(instance.isValid(DEC_03_2007_AT_5PM), "Same date should be valid");
 		
-		assertFalse("One nano before should not be valid", instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)));
-		assertFalse("Null should not be valid", instance.isValid(null));
+		assertFalse(instance.isValid(DEC_03_2007_AT_5PM.minus(1, ChronoUnit.NANOS)), "One nano before should not be valid");
+		assertFalse(instance.isValid(null), "Null should not be valid");
 
 		assertEquals(INVALID_SPECIFICATION_MESSAGE, instance.getInvalidSpecificationMessage());
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valid/StringValidatorTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valid/StringValidatorTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valid;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/BigDecTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/BigDecTypeTest.java
@@ -1,13 +1,11 @@
 package org.yarnandtail.andhow.valuetype;
 
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 import java.math.BigDecimal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for BigDecType
@@ -16,8 +14,6 @@ import static org.junit.Assert.*;
  */
 public class BigDecTypeTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     private static final String PARSE_ERROR_MSG = "Unable to convert to a BigDecimal numeric value";
     private BigDecType type = BigDecType.instance();
 
@@ -32,16 +28,22 @@ public class BigDecTypeTest {
 
     @Test
     public void testParseEmpty() throws ParsingException {
-        expectParsingException();
         assertFalse(type.isParsable(""));
-        type.parse("");
+
+        Exception e = assertThrows(ParsingException.class, () ->
+            type.parse("")
+        );
+        assertEquals(PARSE_ERROR_MSG, e.getMessage());
     }
 
     @Test
     public void testParseNotANumber() throws ParsingException {
-        expectParsingException();
         assertFalse(type.isParsable("apple"));
-        type.parse("apple");
+
+        Exception e = assertThrows(ParsingException.class, () ->
+            type.parse("apple")
+        );
+        assertEquals(PARSE_ERROR_MSG, e.getMessage());
     }
 
     @Test
@@ -51,8 +53,4 @@ public class BigDecTypeTest {
         assertNotNull(type.cast(o));
     }
 
-    private void expectParsingException() {
-        thrown.expect(ParsingException.class);
-        thrown.expectMessage(PARSE_ERROR_MSG);
-    }
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/DblTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/DblTypeTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valuetype;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**
@@ -38,18 +38,24 @@ public class DblTypeTest {
 
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseNotANumber() throws ParsingException {
+	@Test
+	public void testParseNotANumber() {
 		DblType type = DblType.instance();
 		assertFalse(type.isParsable("apple"));
-		type.parse("apple");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("apple")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseEmpty() throws ParsingException {
+	@Test
+	public void testParseEmpty() {
 		DblType type = DblType.instance();
 		assertFalse(type.isParsable(""));
-		type.parse("");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("")
+		);
 	}
 	
 	@Test

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/IntTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/IntTypeTest.java
@@ -2,8 +2,8 @@
  */
 package org.yarnandtail.andhow.valuetype;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**
@@ -24,39 +24,54 @@ public class IntTypeTest {
 		assertNull(type.parse(null));
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseDecimalNumber() throws ParsingException {
+	@Test
+	public void testParseDecimalNumber() {
 		IntType type = IntType.instance();
 		assertFalse(type.isParsable("1234.1234"));
-		type.parse("1234.1234");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("1234.1234")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseNotANumber() throws ParsingException {
+	@Test
+	public void testParseNotANumber() {
 		IntType type = IntType.instance();
 		assertFalse(type.isParsable("apple"));
-		type.parse("apple");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("apple")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
+	@Test
 	public void testParseEmpty() throws ParsingException {
 		IntType type = IntType.instance();
 		assertFalse(type.isParsable(""));
-		type.parse("");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseTooBig() throws ParsingException {
+	@Test
+	public void testParseTooBig() {
 		IntType type = IntType.instance();
 		assertFalse(type.isParsable("9999999999999999999999999999999999999999"));
-		type.parse("9999999999999999999999999999999999999999");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("9999999999999999999999999999999999999999")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseTooSmall() throws ParsingException {
+	@Test
+	public void testParseTooSmall() {
 		IntType type = IntType.instance();
 		assertFalse(type.isParsable("-9999999999999999999999999999999999999999"));
-		type.parse("-9999999999999999999999999999999999999999");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("-9999999999999999999999999999999999999999")
+		);
 	}
 	
 	@Test

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/LngTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/LngTypeTest.java
@@ -1,7 +1,7 @@
 package org.yarnandtail.andhow.valuetype;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**
@@ -9,8 +9,6 @@ import org.yarnandtail.andhow.api.ParsingException;
  * @author ericeverman
  */
 public class LngTypeTest {
-	
-
 
 	@Test
 	public void testParseHappyPath() throws ParsingException {
@@ -22,39 +20,54 @@ public class LngTypeTest {
 		assertNull(type.parse(null));
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseDecimalNumber() throws ParsingException {
+	@Test
+	public void testParseDecimalNumber() {
 		LngType type = LngType.instance();
 		assertFalse(type.isParsable("1234.1234"));
-		type.parse("1234.1234");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("1234.1234")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
+	@Test
 	public void testParseNotANumber() throws ParsingException {
 		LngType type = LngType.instance();
 		assertFalse(type.isParsable("apple"));
-		type.parse("apple");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("apple")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
+	@Test
 	public void testParseEmpty() throws ParsingException {
 		LngType type = LngType.instance();
 		assertFalse(type.isParsable(""));
-		type.parse("");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseTooBig() throws ParsingException {
+	@Test
+	public void testParseTooBig() {
 		LngType type = LngType.instance();
 		assertFalse(type.isParsable("9999999999999999999999999999999999999999"));
-		type.parse("9999999999999999999999999999999999999999");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("9999999999999999999999999999999999999999")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseTooSmall() throws ParsingException {
+	@Test
+	public void testParseTooSmall() {
 		LngType type = LngType.instance();
 		assertFalse(type.isParsable("-9999999999999999999999999999999999999999"));
-		type.parse("-9999999999999999999999999999999999999999");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("-9999999999999999999999999999999999999999")
+		);
 	}
 	
 	@Test

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/LocalDateTimeTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/LocalDateTimeTypeTest.java
@@ -3,8 +3,8 @@
 package org.yarnandtail.andhow.valuetype;
 
 import java.time.LocalDateTime;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**
@@ -12,8 +12,6 @@ import org.yarnandtail.andhow.api.ParsingException;
  * @author ericeverman
  */
 public class LocalDateTimeTypeTest {
-	
-
 
 	@Test
 	public void testParseHappyPath() throws ParsingException {
@@ -32,32 +30,44 @@ public class LocalDateTimeTypeTest {
 		assertNull(type.parse(null));
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseTooManyDecimalPlaces() throws ParsingException {
+	@Test
+	public void testParseTooManyDecimalPlaces() {
 		LocalDateTimeType type = LocalDateTimeType.instance();
 		assertFalse(type.isParsable("2007-12-03T10:15:30.1234567891"));
-		type.parse("2007-12-03T10:15:30.1234567891");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("2007-12-03T10:15:30.1234567891")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseEmpty() throws ParsingException {
+	@Test
+	public void testParseEmpty() {
 		LocalDateTimeType type = LocalDateTimeType.instance();
 		assertFalse(type.isParsable(""));
-		type.parse("");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseIncorrect24Hour() throws ParsingException {
+	@Test
+	public void testParseIncorrect24Hour() {
 		LocalDateTimeType type = LocalDateTimeType.instance();
 		assertFalse(type.isParsable("2007-12-03T24:15:30.123456789"));
-		type.parse("2007-12-03T24:15:30.123456789");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("2007-12-03T24:15:30.123456789")
+		);
 	}
 	
-	@Test(expected=ParsingException.class)
-	public void testParseMissingZeroPadding() throws ParsingException {
+	@Test
+	public void testParseMissingZeroPadding() {
 		LocalDateTimeType type = LocalDateTimeType.instance();
 		assertFalse(type.isParsable("2007-12-03T10:15:3"));
-		type.parse("2007-12-03T10:15:3");
+
+		assertThrows(ParsingException.class, () ->
+			type.parse("2007-12-03T10:15:3")
+		);
 	}
 	
 	@Test

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/StrTypeTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/valuetype/StrTypeTest.java
@@ -2,8 +2,8 @@
  */
 package org.yarnandtail.andhow.valuetype;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.api.ParsingException;
 
 /**

--- a/andhow-testing/andhow-annotation-processor-test-harness/pom.xml
+++ b/andhow-testing/andhow-annotation-processor-test-harness/pom.xml
@@ -15,15 +15,23 @@
 		and creating and testing files in memory.
 	</description>
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>andhow-core</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.7.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
 		</dependency>
     </dependencies>
 </project>

--- a/andhow-testing/andhow-annotation-processor-test-harness/src/test/java/org/yarnandtail/compile/MemoryFileManagerTest.java
+++ b/andhow-testing/andhow-annotation-processor-test-harness/src/test/java/org/yarnandtail/compile/MemoryFileManagerTest.java
@@ -6,10 +6,10 @@ import java.io.IOException;
 import java.io.Writer;
 import javax.tools.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -24,7 +24,7 @@ public class MemoryFileManagerTest {
 	public MemoryFileManagerTest() {
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		compiler = ToolProvider.getSystemJavaCompiler();
 		manager = new MemoryFileManager(compiler);

--- a/andhow-testing/andhow-annotation-processor-test-harness/src/test/java/org/yarnandtail/compile/MemoryFileManagerTest.java
+++ b/andhow-testing/andhow-annotation-processor-test-harness/src/test/java/org/yarnandtail/compile/MemoryFileManagerTest.java
@@ -5,9 +5,7 @@ package org.yarnandtail.compile;
 import java.io.IOException;
 import java.io.Writer;
 import javax.tools.*;
-import javax.tools.JavaFileManager.Location;
-import org.yarnandtail.compile.MemoryFileManager;
-import org.yarnandtail.compile.TestClassLoader;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/andhow-testing/andhow-annotation-processor-tests/pom.xml
+++ b/andhow-testing/andhow-annotation-processor-tests/pom.xml
@@ -37,10 +37,17 @@
 		
 		<!-- All dependencies are test dependencies only -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.7.2</version>
+			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/andhow-testing/andhow-annotation-processor-tests/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrarLoaderTest.java
+++ b/andhow-testing/andhow-annotation-processor-tests/src/test/java/org/yarnandtail/andhow/service/PropertyRegistrarLoaderTest.java
@@ -1,12 +1,13 @@
 package org.yarnandtail.andhow.service;
 
 import java.util.List;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.internal.NameAndProperty;
 import org.yarnandtail.classvistests.sample.NonStaticInnerClassSample;
 import org.yarnandtail.classvistests.sample.PropertySample;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.yarnandtail.andhow.api.GroupProxy;
 

--- a/andhow-testing/andhow-annotation-processor-tests/src/test/java/org/yarnandtail/classvistests/nonapp/sample/VisibilitySampleTest.java
+++ b/andhow-testing/andhow-annotation-processor-tests/src/test/java/org/yarnandtail/classvistests/nonapp/sample/VisibilitySampleTest.java
@@ -2,9 +2,9 @@ package org.yarnandtail.classvistests.nonapp.sample;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * These are some characterization tests of how visibility of non-public

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/pom.xml
@@ -14,25 +14,6 @@
 	<description>Sample to be used as a compiled jar by the 
 		andhow-default-behavior-test to test property behavior
 		in external compiled libraries.</description>
-		
-	<dependencies>
-		<dependency>
-			<!-- Using the combined, single jar dependency -->
-			<groupId>org.yarnandtail</groupId>
-			<artifactId>andhow</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<!-- Using the combined, single jar dependency -->
-			<groupId>org.yarnandtail</groupId>
-			<artifactId>andhow-test-harness</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-	</dependencies>
+
 
 </project>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerNotUsingAHBaseTestClassTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerNotUsingAHBaseTestClassTest.java
@@ -1,7 +1,7 @@
 package com.dep1;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java
@@ -1,12 +1,12 @@
 package com.dep1;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-import org.yarnandtail.andhow.AndHowTestBase;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import static org.junit.jupiter.api.Assertions.*;
+import org.yarnandtail.andhow.AndHowJunit5TestBase;
 import org.yarnandtail.andhow.NonProductionConfig;
 
-import static org.junit.Assert.*;
 
 /**
  * Note that these test methods are specified to be executed in Alph sort order
@@ -14,8 +14,8 @@ import static org.junit.Assert.*;
  * 
  * @author ericeverman
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class EarthMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class EarthMapMakerUsingAHBaseTestClassTest extends AndHowJunit5TestBase {
 	
 	public EarthMapMakerUsingAHBaseTestClassTest() {
 	}

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/pom.xml
@@ -12,24 +12,5 @@
 		andhow-default-behavior-test to test property behavior
 		in external compiled libraries.</description>
 
-	<dependencies>
-		<dependency>
-			<!-- Using the combined, single jar dependency -->
-			<groupId>org.yarnandtail</groupId>
-			<artifactId>andhow</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<!-- Using the combined, single jar dependency -->
-			<groupId>org.yarnandtail</groupId>
-			<artifactId>andhow-test-harness</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-	</dependencies>
 
 </project>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerNotUsingAHBaseTestClassTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerNotUsingAHBaseTestClassTest.java
@@ -1,7 +1,7 @@
 package com.dep2;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerUsingAHBaseTestClassTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/test/java/com/dep2/MarsMapMakerUsingAHBaseTestClassTest.java
@@ -1,12 +1,12 @@
 package com.dep2;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-import org.yarnandtail.andhow.AndHowTestBase;
-import org.yarnandtail.andhow.NonProductionConfig;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.*;
+import org.yarnandtail.andhow.AndHowJunit5TestBase;
+import org.yarnandtail.andhow.NonProductionConfig;
 
 /**
  * Note that these test methods are specified to be executed in Alph sort order
@@ -14,8 +14,8 @@ import static org.junit.Assert.*;
  * 
  * @author ericeverman
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class MarsMapMakerUsingAHBaseTestClassTest extends AndHowTestBase {
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class MarsMapMakerUsingAHBaseTestClassTest extends AndHowJunit5TestBase {
 	
 	public MarsMapMakerUsingAHBaseTestClassTest() {
 	}

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/pom.xml
@@ -25,22 +25,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<!-- Using the combined, single jar dependency -->
-			<groupId>org.yarnandtail</groupId>
-			<artifactId>andhow</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>andhow-test-harness</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 		</dependency>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
@@ -1,16 +1,16 @@
 package com.dep1;
 
 import org.dataprocess.ExternalServiceConnector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.LoaderProblem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep1/EarthMapMakerTest.java
@@ -1,22 +1,19 @@
 package com.dep1;
 
 import org.dataprocess.ExternalServiceConnector;
-import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.LoaderProblem;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
  * @author ericeverman
  */
-public class EarthMapMakerTest extends AndHowTestBase {
+public class EarthMapMakerTest extends AndHowJunit5TestBase {
 
 	@Test
 	public void testConfigFromPropertiesFileOnly() {

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
@@ -1,6 +1,5 @@
 package com.dep2;
 
-import com.dep2.*;
 import org.dataprocess.ExternalServiceConnector;
 import org.junit.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
@@ -1,22 +1,19 @@
 package com.dep2;
 
 import org.dataprocess.ExternalServiceConnector;
-import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.LoaderProblem;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
  * @author ericeverman
  */
-public class MarsMapMakerTest extends AndHowTestBase {
+public class MarsMapMakerTest extends AndHowJunit5TestBase {
 
 	@Test
 	public void testConfigFromPropertiesFileOnly() {

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/com/dep2/MarsMapMakerTest.java
@@ -1,16 +1,16 @@
 package com.dep2;
 
 import org.dataprocess.ExternalServiceConnector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.api.AppFatalException;
 import org.yarnandtail.andhow.internal.LoaderProblem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
@@ -1,9 +1,9 @@
 package org.dataprocess;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.AndHowTestBase;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/test/java/org/dataprocess/ExternalServiceConnectorTest.java
@@ -1,15 +1,15 @@
 package org.dataprocess;
 
-import org.junit.jupiter.api.Test;
-import org.yarnandtail.andhow.AndHowTestBase;
+import org.yarnandtail.andhow.AndHowJunit5TestBase;
 
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
  * @author ericeverman
  */
-public class ExternalServiceConnectorTest extends AndHowTestBase {
+public class ExternalServiceConnectorTest extends AndHowJunit5TestBase {
 	
 	public ExternalServiceConnectorTest() {
 	}

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
@@ -14,4 +14,45 @@
         <module>andhow-default-behavior-dep1</module>
         <module>andhow-default-behavior-dep2</module>
     </modules>
+
+    <dependencies>
+        <dependency>
+            <!-- Using the combined, single jar dependency -->
+            <groupId>org.yarnandtail</groupId>
+            <artifactId>andhow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <!-- Using the combined, single jar dependency -->
+            <groupId>org.yarnandtail</groupId>
+            <artifactId>andhow-test-harness</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- Using the combined, single jar dependency -->
+            <groupId>org.yarnandtail</groupId>
+            <artifactId>andhow-test-harness</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
@@ -23,15 +23,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <!-- Using the combined, single jar dependency -->
             <groupId>org.yarnandtail</groupId>
             <artifactId>andhow-test-harness</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
         <!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
         <dependency>
@@ -45,14 +40,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-        </dependency>
-
-        <dependency>
-            <!-- Using the combined, single jar dependency -->
-            <groupId>org.yarnandtail</groupId>
-            <artifactId>andhow-test-harness</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/andhow-testing/andhow-system-tests/pom.xml
+++ b/andhow-testing/andhow-system-tests/pom.xml
@@ -20,7 +20,7 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>andhow</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -28,11 +28,18 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- All dependencies are test dependencies only -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
+			<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/andhow-testing/andhow-system-tests/pom.xml
+++ b/andhow-testing/andhow-system-tests/pom.xml
@@ -28,11 +28,7 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-		</dependency>
+
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>

--- a/andhow-testing/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-testing/andhow-system-tests/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -1,11 +1,13 @@
 package org.yarnandtail.andhow;
 
 import java.lang.reflect.Field;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.*;
 import org.yarnandtail.andhow.name.CaseInsensitiveNaming;
 import org.yarnandtail.andhow.property.StrProp;
 
-import static org.junit.Assert.*;
 
 /**
  * 
@@ -24,12 +26,12 @@ public class AndHowTest {
 
 	private AndHow originalAndHowInstance;
 	
-	@Before
+	@BeforeEach
 	public void clearAndHow() {
 		originalAndHowInstance = setAndHowInstance(null);
 	}
 	
-	@After
+	@AfterEach
 	public void restoreAndHow() {
 		setAndHowInstance(originalAndHowInstance);
 	}
@@ -45,8 +47,8 @@ public class AndHowTest {
 		AndHowConfiguration<? extends AndHowConfiguration> config1 = AndHow.findConfig();
 		AndHowConfiguration<? extends AndHowConfiguration> config2 = AndHow.findConfig();
 		
-		assertNotEquals("Should return a new instance each time", config1, config2);
-		assertFalse("findConfig should not force initialization", AndHow.isInitialize());
+		assertNotEquals(config1, config2, "Should return a new instance each time");
+		assertFalse(AndHow.isInitialize(), "findConfig should not force initialization");
 	}
 
 	/**

--- a/andhow-testing/andhow-test-harness/pom.xml
+++ b/andhow-testing/andhow-test-harness/pom.xml
@@ -19,18 +19,49 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>andhow-core</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
+			<scope>compile</scope>
+			<optional>true</optional>
 		</dependency>
-		<!-- All dependencies are test dependencies only -->
+
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
+			<!-- This should be optional, but is a too baked in.
+			This issue:  https://github.com/eeverman/andhow/issues/309
+			  should remove it -->
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>compile</scope>
+		</dependency>
+
+		<!--
+		This package is designed to be used unit testing utils for apps,
+		so dependencies that would normally be test scope are compile scope.
+		However, they are optional so that the downstream app can choose if
+		it wants to use Junit 4 or 5 (and use newer versions than what is
+		used here).
+		-->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowJunit4TestBase.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowJunit4TestBase.java
@@ -1,6 +1,9 @@
 package org.yarnandtail.andhow;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 
 /**
@@ -14,11 +17,10 @@ import org.junit.*;
  *
  * <a href="https://github.com/eeverman/andhow/blob/master/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java#L25">
  *   Here is a example</a>Here is a example that shows how this can be used.
- * 
+ *
  * @author eeverman
- * @depricated Use AndHowJunit4TestBase instead, or upgrade to AndHowJunit5TestBase.
  */
-public class AndHowTestBase extends AndHowTestBaseImpl {
+public class AndHowJunit4TestBase extends AndHowTestBaseImpl {
 
 	/**
 	 * Stores the AndHow Core (its state) and System Properties prior to a test class.

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowJunit5TestBase.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowJunit5TestBase.java
@@ -1,6 +1,9 @@
 package org.yarnandtail.andhow;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 
 /**
@@ -14,11 +17,10 @@ import org.junit.*;
  *
  * <a href="https://github.com/eeverman/andhow/blob/master/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java#L25">
  *   Here is a example</a>Here is a example that shows how this can be used.
- * 
+ *
  * @author eeverman
- * @depricated Use AndHowJunit4TestBase instead, or upgrade to AndHowJunit5TestBase.
  */
-public class AndHowTestBase extends AndHowTestBaseImpl {
+public class AndHowJunit5TestBase extends AndHowTestBaseImpl {
 
 	/**
 	 * Stores the AndHow Core (its state) and System Properties prior to a test class.
@@ -26,7 +28,7 @@ public class AndHowTestBase extends AndHowTestBaseImpl {
 	 * related class) to SEVERE.  If JNDI is used for a test, it's startup
 	 * is verbose to System.out, so this turns it off.
 	 */
-	@BeforeClass
+	@BeforeAll
 	public static void andHowSnapshotBeforeTestClass() {
 		AndHowTestBaseImpl.andHowSnapshotBeforeTestClass();
 	}
@@ -37,7 +39,7 @@ public class AndHowTestBase extends AndHowTestBaseImpl {
 	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
 	 * related class) to what ever it was prior to the run.
 	 */
-	@AfterClass
+	@AfterAll
 	public static void resetAndHowSnapshotAfterTestClass() {
 		AndHowTestBaseImpl.resetAndHowSnapshotAfterTestClass();
 	}
@@ -48,7 +50,7 @@ public class AndHowTestBase extends AndHowTestBaseImpl {
 	 * related class) to SEVERE.  If JNDI is used for a test, it's startup
 	 * is verbose to System.out, so this turns it off.
 	 */
-	@Before
+	@BeforeEach
 	public void andHowSnapshotBeforeSingleTest() {
 		super.andHowSnapshotBeforeSingleTest();
 	}
@@ -59,7 +61,7 @@ public class AndHowTestBase extends AndHowTestBaseImpl {
 	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
 	 * related class) to what ever it was prior to the run.
 	 */
-	@After
+	@AfterEach
 	public void resetAndHowSnapshotAfterSingleTest() {
 		super.resetAndHowSnapshotAfterSingleTest();
 	}

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
@@ -60,6 +60,7 @@ public class AndHowTestBaseImpl {
 	 * that were previously stored prior to this class' test run.
 	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
 	 * related class) to what ever it was prior to the run.
+	 * Any JNDI bindings set via getJndi() are cleared.
 	 */
 	public static void resetAndHowSnapshotAfterTestClass() {
 		System.setProperties(beforeClassSystemProps);
@@ -68,12 +69,26 @@ public class AndHowTestBaseImpl {
 		//Reset to the log level prior to the test class
 		Logger.getGlobal().setLevel(beforeClassLogLevel);
 		Logger.getLogger(SimpleNamingContextBuilder.class.getCanonicalName()).setLevel(beforeClassLogLevel);
+
+		if (builder != null) {
+			builder.clear();
+			builder.deactivate();
+		}
 	}
 
 	/**
 	 * Simple consistent way to get an empty JNDI context.
 	 * <p>
-	 * bind() each variable, then call build().
+	 * Call {@code SimpleNamingContextBuilder.bind()} for each variable to add
+	 * to the context, then {@code SimpleNamingContextBuilder.activate()} to
+	 * make the context active.  To fetch values from the context,
+	 * use:
+	 * <pre>{@code
+	 * InitialContext ctx = new InitialContext();
+	 * ctx.lookup("java:comp/some/name");
+	 * }</pre>
+	 * The context is deactivated and cleared after each test and after the
+	 * test class completes.
 	 *
 	 * @deprecated This will be removed in the next major release to avoid
 	 * having JNDI dependencies in a user visible class.  Most user will not
@@ -104,6 +119,7 @@ public class AndHowTestBaseImpl {
 	 * that were previously stored prior to a test run.
 	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
 	 * related class) to what ever it was prior to the run.
+	 * Any JNDI bindings set via getJndi() are cleared.
 	 */
 	public void resetAndHowSnapshotAfterSingleTest() {
 		System.setProperties(beforeTestSystemProps);
@@ -111,6 +127,7 @@ public class AndHowTestBaseImpl {
 
 		if (builder != null) {
 			builder.clear();
+			builder.deactivate();
 		}
 	}
 }

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
@@ -1,0 +1,113 @@
+package org.yarnandtail.andhow;
+
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+import org.yarnandtail.andhow.internal.AndHowCore;
+
+import javax.naming.NamingException;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Base class for AndHowJunit4/5TestBase classes.
+ * See those classes for documentation.
+ */
+public class AndHowTestBaseImpl {
+	private static AndHowCore beforeClassCore;
+	private static Level beforeClassLogLevel;
+	/**
+	 * System properties before the tests and subclass @BeforeClass initializer
+	 * are run.  Properties prior to the initialization of this test class are
+	 * stored and then reinstated after the test class is complete.
+	 */
+	private static Properties beforeClassSystemProps;
+	/**
+	 * Builder for a temporary JNDI context
+	 */
+	private static SimpleNamingContextBuilder builder;
+	private AndHowCore beforeTestCore;
+	/**
+	 * System properties before an individual test is run and the subclass @Before
+	 * initializers are run.  Properties prior to a test are
+	 * stored and then reinstated after the test is complete.  If a Test classes
+	 * uses a @BeforeClass initializer that sets system properties, this will
+	 * reinstate to that state.
+	 */
+	private Properties beforeTestSystemProps;
+
+	/**
+	 * Stores the AndHow Core (its state) and System Properties prior to a test class.
+	 * It also sets the logging level for SimpleNamingContextBuilder (a JNDI
+	 * related class) to SEVERE.  If JNDI is used for a test, it's startup
+	 * is verbose to System.out, so this turns it off.
+	 */
+	public static void andHowSnapshotBeforeTestClass() {
+		//The SimpleNamingContextBuilder uses Commons Logging, which defaults to
+		//using Java logging.  It spews a bunch of stuff the console during tests,
+		//so this turns that off.
+
+		beforeClassLogLevel = Logger.getGlobal().getLevel();  //store log level before class
+		Logger.getGlobal().setLevel(Level.SEVERE);
+		Logger.getLogger(SimpleNamingContextBuilder.class.getCanonicalName()).setLevel(Level.SEVERE);
+
+
+		beforeClassCore = AndHowNonProductionUtil.getAndHowCore();
+		beforeClassSystemProps = AndHowNonProductionUtil.clone(System.getProperties());
+	}
+
+	/**
+	 * Restores the AndHow Core (its state) and System Properties
+	 * that were previously stored prior to this class' test run.
+	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
+	 * related class) to what ever it was prior to the run.
+	 */
+	public static void resetAndHowSnapshotAfterTestClass() {
+		System.setProperties(beforeClassSystemProps);
+		AndHowNonProductionUtil.setAndHowCore(beforeClassCore);
+
+		//Reset to the log level prior to the test class
+		Logger.getGlobal().setLevel(beforeClassLogLevel);
+		Logger.getLogger(SimpleNamingContextBuilder.class.getCanonicalName()).setLevel(beforeClassLogLevel);
+	}
+
+	/**
+	 * Simple consistent way to get an empty JNDI context.
+	 * <p>
+	 * bind() each variable, then call build().
+	 *
+	 * @return A JNDI context for setting properties via JNDI.
+	 * @throws NamingException If JNDI cannot be initiated.
+	 */
+	public SimpleNamingContextBuilder getJndi() throws NamingException {
+		if (builder == null) {
+			builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
+		}
+		return builder;
+	}
+
+	/**
+	 * Stores the AndHow Core (its state) and System Properties prior to a test.
+	 * It also sets the logging level for SimpleNamingContextBuilder (a JNDI
+	 * related class) to SEVERE.  If JNDI is used for a test, it's startup
+	 * is verbose to System.out, so this turns it off.
+	 */
+	public void andHowSnapshotBeforeSingleTest() {
+		beforeTestSystemProps = AndHowNonProductionUtil.clone(System.getProperties());
+		beforeTestCore = AndHowNonProductionUtil.getAndHowCore();
+	}
+
+	/**
+	 * Restores the AndHow Core (its state) and System Properties
+	 * that were previously stored prior to a test run.
+	 * It also resets the logging level for SimpleNamingContextBuilder (a JNDI
+	 * related class) to what ever it was prior to the run.
+	 */
+	public void resetAndHowSnapshotAfterSingleTest() {
+		System.setProperties(beforeTestSystemProps);
+		AndHowNonProductionUtil.setAndHowCore(beforeTestCore);
+
+		if (builder != null) {
+			builder.clear();
+		}
+	}
+}

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBaseImpl.java
@@ -75,6 +75,9 @@ public class AndHowTestBaseImpl {
 	 * <p>
 	 * bind() each variable, then call build().
 	 *
+	 * @deprecated This will be removed in the next major release to avoid
+	 * having JNDI dependencies in a user visible class.  Most user will not
+	 * need to test their apps with JNDI.
 	 * @return A JNDI context for setting properties via JNDI.
 	 * @throws NamingException If JNDI cannot be initiated.
 	 */

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowJunit4TestBaseTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowJunit4TestBaseTest.java
@@ -1,0 +1,66 @@
+package org.yarnandtail.andhow;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The implementation is all in the base class, so here tests are minimal
+ * to make sure the base class is being called.
+ */
+class AndHowJunit4TestBaseTest {
+
+	static final String BOB = "bob";
+
+	@Test
+	void andHowSnapshotBeforeAndAfterTestClass() {
+
+		Properties originalProperties = System.getProperties();
+
+		try {
+
+			//We shouldn't have this property before we start
+			assertNull(System.getProperty(BOB));
+
+			//Take the snapshot
+			AndHowJunit4TestBase.andHowSnapshotBeforeTestClass();
+
+			//Sys props - completely mess them up - reset should reset them...
+			System.setProperties(new Properties());  //zap all properties
+			System.setProperty(BOB, BOB);
+
+
+			//Are the sysProps messed up just like we did above?
+			assertEquals(BOB, System.getProperty(BOB));
+			assertEquals(1, System.getProperties().size());
+
+			//
+			//reset
+			AndHowJunit4TestBase.resetAndHowSnapshotAfterTestClass();
+
+
+			//Verify we have the exact same set of SysProps after the reset
+			assertEquals(originalProperties.size(), System.getProperties().size());
+			assertTrue(originalProperties.entrySet().containsAll(System.getProperties().entrySet()));
+
+		} finally {
+			System.setProperties(originalProperties);
+		}
+
+	}
+
+
+	@Test
+	void andHowSnapshotBeforeAndAfterSingleTest() {
+
+		AndHowJunit4TestBase testBase = new AndHowJunit4TestBase();
+		AndHowTestBaseImplTest implTest = new AndHowTestBaseImplTest();
+
+		implTest.doAndHowSnapshotBeforeAndAfterSingleTest(testBase);
+
+	}
+
+
+}

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowJunit5TestBaseTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowJunit5TestBaseTest.java
@@ -1,0 +1,66 @@
+package org.yarnandtail.andhow;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The implementation is all in the base class, so here tests are minimal
+ * to make sure the base class is being called.
+ */
+class AndHowJunit5TestBaseTest {
+
+	static final String BOB = "bob";
+
+	@Test
+	void andHowSnapshotBeforeAndAfterTestClass() {
+
+		Properties originalProperties = System.getProperties();
+
+		try {
+
+			//We shouldn't have this property before we start
+			assertNull(System.getProperty(BOB));
+
+			//Take the snapshot
+			AndHowJunit5TestBase.andHowSnapshotBeforeTestClass();
+
+			//Sys props - completely mess them up - reset should reset them...
+			System.setProperties(new Properties());  //zap all properties
+			System.setProperty(BOB, BOB);
+
+
+			//Are the sysProps messed up just like we did above?
+			assertEquals(BOB, System.getProperty(BOB));
+			assertEquals(1, System.getProperties().size());
+
+			//
+			//reset
+			AndHowJunit5TestBase.resetAndHowSnapshotAfterTestClass();
+
+
+			//Verify we have the exact same set of SysProps after the reset
+			assertEquals(originalProperties.size(), System.getProperties().size());
+			assertTrue(originalProperties.entrySet().containsAll(System.getProperties().entrySet()));
+
+		} finally {
+			System.setProperties(originalProperties);
+		}
+
+	}
+
+
+	@Test
+	void andHowSnapshotBeforeAndAfterSingleTest() {
+
+		AndHowJunit5TestBase testBase = new AndHowJunit5TestBase();
+		AndHowTestBaseImplTest implTest = new AndHowTestBaseImplTest();
+
+		implTest.doAndHowSnapshotBeforeAndAfterSingleTest(testBase);
+
+	}
+
+
+}

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowNonProductionUtilTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowNonProductionUtilTest.java
@@ -3,10 +3,10 @@
 package org.yarnandtail.andhow;
 
 import java.util.Properties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.internal.AndHowCore;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -62,7 +62,7 @@ public class AndHowNonProductionUtilTest extends AndHowTestingTestBase {
 		AndHowNonProductionUtil.setAndHowCore(ahCore1);	//swap cores
 		
 		//The key assertion
-		assertTrue("Should have inserted a new core", ahCore1 == AndHowNonProductionUtil.getAndHowCore());
+		assertTrue(ahCore1 == AndHowNonProductionUtil.getAndHowCore(), "Should have inserted a new core");
 	}
 
 	/**
@@ -75,12 +75,12 @@ public class AndHowNonProductionUtilTest extends AndHowTestingTestBase {
 		AndHowConfiguration config = AndHow.findConfig();
 		AndHowNonProductionUtil.forceRebuild(config);	//Should be OK even when a new build
 		AndHowCore ahCore1 = AndHowNonProductionUtil.getAndHowCore();
-		assertNotNull("Util should create a new instance even if no current instance", ahCore1);
+		assertNotNull(ahCore1, "Util should create a new instance even if no current instance");
 		
 		AndHowNonProductionUtil.forceRebuild(config);	//Now an actual rebuild
 		AndHowCore ahCore2 = AndHowNonProductionUtil.getAndHowCore();
 		assertNotNull(ahCore2);
-		assertFalse("The core instances should be different instances", ahCore1 == ahCore2);
+		assertFalse(ahCore1 == ahCore2, "The core instances should be different instances");
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class AndHowNonProductionUtilTest extends AndHowTestingTestBase {
 	@Test
 	public void testDestroyAndHowCore() {
 
-		assertNull("AndHow should be null at test start", AndHowNonProductionUtil.getAndHowInstance());
+		assertNull(AndHowNonProductionUtil.getAndHowInstance(), "AndHow should be null at test start");
 		AndHow.instance();	//force creation
 		AndHowNonProductionUtil.destroyAndHowCore();
 		assertNotNull(AndHowNonProductionUtil.getAndHowInstance());

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseImplTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseImplTest.java
@@ -1,0 +1,136 @@
+package org.yarnandtail.andhow;
+
+import org.junit.jupiter.api.Test;
+import org.yarnandtail.andhow.internal.AndHowCore;
+import org.yarnandtail.andhow.property.FlagProp;
+import org.yarnandtail.andhow.property.StrProp;
+
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AndHowTestBaseImplTest {
+
+	static final String BOB_NAME = SimpleConfig.class.getCanonicalName() + ".BOB";
+	static final String BOB_VALUE = "BobsYourUncle";
+
+	@Test
+	void andHowSnapshotBeforeAndAfterTestClass() {
+
+		AndHowCore beforeTheTestCore = AndHowNonProductionUtil.getAndHowCore();
+		Properties originalProperties = System.getProperties();
+		Level beforeClassLogLevel = Logger.getGlobal().getLevel();  //store log level before class
+
+		try {
+
+			//We shouldn't have this property before we start
+			assertNull(System.getProperty(BOB_NAME));
+
+			//Take the snapshot
+			AndHowTestBaseImpl.andHowSnapshotBeforeTestClass();
+
+			//Sys props - completely mess them up - reset should reset them...
+			System.setProperties(new Properties());	//zap all properties
+			System.setProperty(BOB_NAME, BOB_VALUE);
+
+			//Now build w/ the new SystemProperties
+			NonProductionConfig.instance().group(SimpleConfig.class).forceBuild();
+
+
+			//Are the sysProps messed up just like we did above?
+			assertEquals(BOB_VALUE, System.getProperty(BOB_NAME));
+			assertEquals(1, System.getProperties().size());
+
+			//Did the AndHow Property get set?
+			assertEquals(BOB_VALUE, SimpleConfig.BOB.getValue());
+
+			//Change the global log level
+			if (beforeClassLogLevel == null || ! beforeClassLogLevel.equals(Level.FINEST)) {
+				Logger.getGlobal().setLevel(Level.FINEST);
+			} else {
+				Logger.getGlobal().setLevel(Level.FINER);
+			}
+
+			//Is the AndHowCore different than what it was originally?
+			assertFalse(beforeTheTestCore == AndHowNonProductionUtil.getAndHowCore());
+
+			//
+			//reset
+			AndHowTestBaseImpl.resetAndHowSnapshotAfterTestClass();
+
+
+			//Verify we have the exact same set of SysProps after the reset
+			assertEquals(originalProperties.size(), System.getProperties().size());
+			assertTrue(originalProperties.entrySet().containsAll(System.getProperties().entrySet()));
+
+			//Verify the core is back to the original
+			assertTrue(beforeTheTestCore == AndHowNonProductionUtil.getAndHowCore());
+
+			//Did the log level get reset?
+			assertEquals(beforeClassLogLevel, Logger.getGlobal().getLevel());
+
+		} finally {
+			AndHowNonProductionUtil.setAndHowCore(beforeTheTestCore);
+			System.setProperties(originalProperties);
+		}
+
+	}
+
+
+	@Test
+	void andHowSnapshotBeforeAndAfterSingleTest() {
+
+		AndHowTestBaseImpl testBase = new AndHowTestBaseImpl();
+
+		AndHowCore beforeTheTestCore = AndHowNonProductionUtil.getAndHowCore();
+		Properties originalProperties = System.getProperties();
+
+		try {
+
+			//We shouldn't have this property before we start
+			assertNull(System.getProperty(BOB_NAME));
+
+			//Take the snapshot
+			testBase.andHowSnapshotBeforeSingleTest();
+
+			//Sys props - completely mess them up - reset should reset them...
+			System.setProperties(new Properties());	//zap all properties
+			System.setProperty(BOB_NAME, BOB_VALUE);
+
+			//Now build w/ the new SystemProperties
+			NonProductionConfig.instance().group(SimpleConfig.class).forceBuild();
+
+
+			//Are the sysProps messed up just like we did above?
+			assertEquals(BOB_VALUE, System.getProperty(BOB_NAME));
+			assertEquals(1, System.getProperties().size());
+
+			//Did the AndHow Property get set?
+			assertEquals(BOB_VALUE, SimpleConfig.BOB.getValue());
+
+			//Is the AndHowCore different than what it was originally?
+			assertFalse(beforeTheTestCore == AndHowNonProductionUtil.getAndHowCore());
+
+			//
+			//reset
+			testBase.resetAndHowSnapshotAfterSingleTest();
+
+
+			//Verify we have the exact same set of SysProps after the reset
+			assertEquals(originalProperties.size(), System.getProperties().size());
+			assertTrue(originalProperties.entrySet().containsAll(System.getProperties().entrySet()));
+
+			//Verify the core is back to the original
+			assertTrue(beforeTheTestCore == AndHowNonProductionUtil.getAndHowCore());
+
+		} finally {
+			AndHowNonProductionUtil.setAndHowCore(beforeTheTestCore);
+			System.setProperties(originalProperties);
+		}
+
+	}
+
+
+}

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseImplTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseImplTest.java
@@ -81,11 +81,13 @@ class AndHowTestBaseImplTest {
 
 	}
 
-
 	@Test
 	void andHowSnapshotBeforeAndAfterSingleTest() {
-
 		AndHowTestBaseImpl testBase = new AndHowTestBaseImpl();
+		doAndHowSnapshotBeforeAndAfterSingleTest(testBase);
+	}
+
+	void doAndHowSnapshotBeforeAndAfterSingleTest(AndHowTestBaseImpl testBase) {
 
 		AndHowCore beforeTheTestCore = AndHowNonProductionUtil.getAndHowCore();
 		Properties originalProperties = System.getProperties();

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestBaseTest.java
@@ -1,0 +1,66 @@
+package org.yarnandtail.andhow;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The implementation is all in the base class, so here tests are minimal
+ * to make sure the base class is being called.
+ */
+class AndHowTestBaseTest {
+
+	static final String BOB = "bob";
+
+	@Test
+	void andHowSnapshotBeforeAndAfterTestClass() {
+
+		Properties originalProperties = System.getProperties();
+
+		try {
+
+			//We shouldn't have this property before we start
+			assertNull(System.getProperty(BOB));
+
+			//Take the snapshot
+			AndHowTestBase.andHowSnapshotBeforeTestClass();
+
+			//Sys props - completely mess them up - reset should reset them...
+			System.setProperties(new Properties());  //zap all properties
+			System.setProperty(BOB, BOB);
+
+
+			//Are the sysProps messed up just like we did above?
+			assertEquals(BOB, System.getProperty(BOB));
+			assertEquals(1, System.getProperties().size());
+
+			//
+			//reset
+			AndHowTestBase.resetAndHowSnapshotAfterTestClass();
+
+
+			//Verify we have the exact same set of SysProps after the reset
+			assertEquals(originalProperties.size(), System.getProperties().size());
+			assertTrue(originalProperties.entrySet().containsAll(System.getProperties().entrySet()));
+
+		} finally {
+			System.setProperties(originalProperties);
+		}
+
+	}
+
+
+	@Test
+	void andHowSnapshotBeforeAndAfterSingleTest() {
+
+		AndHowTestBase testBase = new AndHowTestBase();
+		AndHowTestBaseImplTest implTest = new AndHowTestBaseImplTest();
+
+		implTest.doAndHowSnapshotBeforeAndAfterSingleTest(testBase);
+
+	}
+
+
+}

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestingTestBase.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestingTestBase.java
@@ -1,8 +1,7 @@
 package org.yarnandtail.andhow;
 
 import java.lang.reflect.Field;
-import java.util.Properties;
-import javax.naming.NamingException;
+
 import org.junit.*;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestingTestBase.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/AndHowTestingTestBase.java
@@ -2,7 +2,10 @@ package org.yarnandtail.andhow;
 
 import java.lang.reflect.Field;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 
 /**
@@ -33,24 +36,24 @@ public class AndHowTestingTestBase {
 	 */
 	private static SimpleNamingContextBuilder builder;
 	
-	@BeforeClass
+	@BeforeAll
 	public static void killAndHowStateBeforeClass() {
 		destroyAndHow();
 	}
 	
 	
-	@Before
+	@BeforeEach
 	public void killAndHowStateBeforeTest() {
 		destroyAndHow();
 	}
 	
 	
-	@After
+	@AfterEach
 	public void killAndHowStateAfterTest() {
 		destroyAndHow();
 	}
 	
-	@AfterClass
+	@AfterAll
 	public static void killAndHowStateAfterClass() {
 		destroyAndHow();
 	}

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/NonProductionConfigTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/NonProductionConfigTest.java
@@ -5,7 +5,7 @@ package org.yarnandtail.andhow;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.yarnandtail.andhow.NonProductionConfig.NonProductionConfigImpl;
 import org.yarnandtail.andhow.api.GroupProxy;
 import org.yarnandtail.andhow.api.Loader;
@@ -14,7 +14,7 @@ import org.yarnandtail.andhow.load.std.StdFixedValueLoader;
 import org.yarnandtail.andhow.load.std.StdMainStringArgsLoader;
 import org.yarnandtail.andhow.property.StrProp;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.yarnandtail.andhow.AndHowNonProductionUtil.PERMISSION_MSG;
 
 /**
@@ -56,11 +56,13 @@ public class NonProductionConfigTest {
 		assertEquals("NULL", kvps.get(2));
 	}
 	
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testAddCmdLineArgWithNull() {
 		NonProductionConfigImpl config = NonProductionConfig.instance();
-		config.addCmdLineArg(null, "one");
-		
+
+		assertThrows(RuntimeException.class, () -> {
+			config.addCmdLineArg(null, "one");
+		});
 	}
 	
 	@Test

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/NonProductionConfigTest.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/NonProductionConfigTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.yarnandtail.andhow.NonProductionConfig.NonProductionConfigImpl;
 import org.yarnandtail.andhow.api.GroupProxy;
 import org.yarnandtail.andhow.api.Loader;
-import org.yarnandtail.andhow.internal.AndHowCore;
 import org.yarnandtail.andhow.load.*;
 import org.yarnandtail.andhow.load.std.StdFixedValueLoader;
 import org.yarnandtail.andhow.load.std.StdMainStringArgsLoader;

--- a/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/SimpleConfig.java
+++ b/andhow-testing/andhow-test-harness/src/test/java/org/yarnandtail/andhow/SimpleConfig.java
@@ -1,0 +1,8 @@
+package org.yarnandtail.andhow;
+
+import org.yarnandtail.andhow.property.StrProp;
+
+public interface SimpleConfig {
+	StrProp BOB = StrProp.builder().build();
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
 				<version>4.13.1</version>
 				<scope>test</scope>
 			</dependency>
-			<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
@@ -168,17 +167,18 @@
 	</dependencyManagement>
 
 	<dependencies>
+		<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,8 @@
 	</dependencyManagement>
 
 	<dependencies>
-		<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
 		<dependency>
+			<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,10 +98,46 @@
 
 	<dependencyManagement>
 		<dependencies>
+
+			<!-- Junit suite
+			Currently switching from Junit 4 to 5, so both are brought in
+			as dependencies.
+			-->
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.13.1</version>
+				<scope>test</scope>
+			</dependency>
+			<!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.7.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-api</artifactId>
+				<version>5.7.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>5.7.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest</artifactId>
+				<version>2.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.vintage</groupId>
+				<artifactId>junit-vintage-engine</artifactId>
+				<version>5.7.2</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -130,6 +166,21 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.7.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.7.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 	
 	<build>
 		<pluginManagement>
@@ -192,6 +243,11 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,16 +99,7 @@
 	<dependencyManagement>
 		<dependencies>
 
-			<!-- Junit suite
-			Currently switching from Junit 4 to 5, so both are brought in
-			as dependencies.
-			-->
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.13.1</version>
-				<scope>test</scope>
-			</dependency>
+			<!-- Junit5 suite of testing dependencies -->
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
@@ -133,12 +124,24 @@
 				<version>2.2</version>
 				<scope>test</scope>
 			</dependency>
+
+			<!--
+			Junit4 used by andhow-test-harness to provide a test base class for
+			app dev's using Junit4.
+			-->
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.13.1</version>
+				<scope>test</scope>
+			</dependency>
 			<dependency>
 				<groupId>org.junit.vintage</groupId>
 				<artifactId>junit-vintage-engine</artifactId>
 				<version>5.7.2</version>
 				<scope>test</scope>
 			</dependency>
+
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-test</artifactId>
@@ -152,10 +155,17 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<!-- Teat framework to test Annotation Processors in a simulated compile env. -->
 				<groupId>com.google.testing.compile</groupId>
 				<artifactId>compile-testing</artifactId>
 				<version>0.15</version>
 				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>junit</groupId>
+						<artifactId>junit</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
@@ -175,10 +185,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
Resolves #501
JUnit 4 is still in the parent pom dependencyManagement section b/c it is still used in the andhow-test-harness module, which has a base class that is intended for use by app dev's using JUnit 4.  A JUnit 5 version of that was added.
Otherwise JUnit 4 has been replaced everywhere.
@VickyRonnen Would you be able to take a look at this PR?