### PR TITLE
Exclude annotation-processor-test-harness from the codecov report

### DIFF
--- a/andhow-annotation-processor/pom.xml
+++ b/andhow-annotation-processor/pom.xml
@@ -42,10 +42,6 @@
 			<groupId>com.google.testing.compile</groupId>
 			<artifactId>compile-testing</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_PropertyTest.java
+++ b/andhow-annotation-processor/src/test/java/org/yarnandtail/andhow/compile/AndHowCompileProcessor_PropertyTest.java
@@ -10,6 +10,7 @@ import org.yarnandtail.andhow.compile.CompileProblem.PropMissingStatic;
 import org.yarnandtail.andhow.compile.CompileProblem.PropMissingStaticFinal;
 import org.yarnandtail.andhow.service.*;
 import org.yarnandtail.andhow.util.IOUtil;
+import org.yarnandtail.compile.AndHowCompileProcessorTestBase;
 
 /**
  * A lot of this code was borrowed from here:

--- a/andhow-core/pom.xml
+++ b/andhow-core/pom.xml
@@ -16,24 +16,12 @@
 	<dependencies>
 		<!-- All dependencies are test dependencies only -->
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-		</dependency>	
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/andhow-testing/andhow-annotation-processor-test-harness/pom.xml
+++ b/andhow-testing/andhow-annotation-processor-test-harness/pom.xml
@@ -24,14 +24,8 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-			<version>2.2</version>
-			<scope>test</scope>
+			<scope>compile</scope>
+			<optional>true</optional>
 		</dependency>
     </dependencies>
 </project>

--- a/andhow-testing/andhow-annotation-processor-test-harness/src/main/java/org/yarnandtail/compile/AndHowCompileProcessorTestBase.java
+++ b/andhow-testing/andhow-annotation-processor-test-harness/src/main/java/org/yarnandtail/compile/AndHowCompileProcessorTestBase.java
@@ -1,4 +1,4 @@
-package org.yarnandtail.andhow.compile;
+package org.yarnandtail.compile;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -8,9 +8,6 @@ import javax.tools.JavaFileObject;
 import javax.tools.ToolProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.yarnandtail.andhow.util.IOUtil;
-import org.yarnandtail.compile.MemoryFileManager;
-import org.yarnandtail.compile.TestClassLoader;
-import org.yarnandtail.compile.TestSource;
 
 /**
  *
@@ -19,17 +16,17 @@ import org.yarnandtail.compile.TestSource;
 public class AndHowCompileProcessorTestBase {
 	
 	/** Classpath of the generated service file for AndHow property registration */
-	static final String REGISTRAR_SVS_PATH = 
+	protected static final String REGISTRAR_SVS_PATH =
 			"/META-INF/services/org.yarnandtail.andhow.service.PropertyRegistrar";
-	static final String INIT_SVS_PATH = "/META-INF/services/org.yarnandtail.andhow.AndHowInit";
-   	static final String TEST_INIT_SVS_PATH = "/META-INF/services/org.yarnandtail.andhow.AndHowTestInit";
-     
-	JavaCompiler compiler;
-	MemoryFileManager manager;
-	DiagnosticCollector<JavaFileObject> diagnostics;
-	TestClassLoader loader;
-	
-	Set<TestSource> sources;	//New set of source files to compile
+	protected static final String INIT_SVS_PATH = "/META-INF/services/org.yarnandtail.andhow.AndHowInit";
+	protected static final String TEST_INIT_SVS_PATH = "/META-INF/services/org.yarnandtail.andhow.AndHowTestInit";
+
+	protected JavaCompiler compiler;
+	protected MemoryFileManager manager;
+	protected DiagnosticCollector<JavaFileObject> diagnostics;
+	protected TestClassLoader loader;
+
+	protected Set<TestSource> sources;	//New set of source files to compile
 	
 	@BeforeEach
 	public void setupTest() {

--- a/andhow-testing/andhow-annotation-processor-tests/pom.xml
+++ b/andhow-testing/andhow-annotation-processor-tests/pom.xml
@@ -34,20 +34,6 @@
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		
-		<!-- All dependencies are test dependencies only -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-			<version>2.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
@@ -28,18 +28,5 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Only needed to run tests in a version of IntelliJ IDEA that bundles older versions -->
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/andhow-testing/andhow-system-tests/pom.xml
+++ b/andhow-testing/andhow-system-tests/pom.xml
@@ -28,15 +28,6 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 ## YAML Template.
 ---
 coverage:
-  range: 0..100
+  range: 50..100
   round: down
   precision: 2
+ignore:
+  - "andhow-testing/andhow-annotation-processor-test-harness"

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
 				<version>5.7.2</version>
 				<scope>test</scope>
 			</dependency>
-
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-test</artifactId>
@@ -185,6 +184,18 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
* Moved the AndHowCompileProcessorTestBase to the test harness module
* cleaned up junit related dependency declaration in pom files