### PR TITLE
Deprecated AndHow.instance(config) and AndHowConfig.build()

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
@@ -254,5 +254,17 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 
 	C insertLoaderAfter(Class<? extends StandardLoader> insertAfterThisLoader, Loader loaderToInsert);
 
+	/**
+	 * Force initialization of AndHow using this configuration instance.
+	 *
+	 * AndHow initialization is a one-time event, so further changes to this configuration will
+	 * have no effect and additional calls to build() will throw runtime exceptions.
+	 *
+	 * @See org.yarnandtail.andhow.AndHow#instance
+	 * @See org.yarnandtail.andhow.AndHow#initialize
+	 * @deprecated This method will be removed in the next major release.
+	 * Use AndHow.instance() or AndHow.initialize()
+	 */
+	@Deprecated
 	void build();
 }

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/BaseConfig.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/BaseConfig.java
@@ -167,6 +167,9 @@ public abstract class BaseConfig<C extends BaseConfig<C>> implements AndHowConfi
 	
 	@Override
 	public void build() {
+		System.err.println(
+				"Config.build() is deprecated and will be removed in the next major release. " +
+						"See Javadocs for alternatives.");
 		AndHow.instance(this);
 	}
 

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/util/AndHowUtil.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/util/AndHowUtil.java
@@ -52,7 +52,7 @@ public class AndHowUtil {
 						appDef.addExportGroup(eg);
 					}
 
-				} catch (InstantiationException ex) {
+				} catch (InstantiationException | NoSuchMethodException | InvocationTargetException ex) {
 					ConstructionProblem.ExportException ee
 							= new ConstructionProblem.ExportException(ex, group,
 									"Unable to created a new instance of one of the Exporters for this group.  "
@@ -136,7 +136,7 @@ public class AndHowUtil {
 	 * @throws IllegalAccessException
 	 */
 	public static List<Exporter> getExporters(GroupProxy group)
-			throws InstantiationException, IllegalAccessException {
+			throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 
 		ArrayList<Exporter> exps = new ArrayList();
 
@@ -145,7 +145,7 @@ public class AndHowUtil {
 		for (GroupExport ge : groupExports) {
 			Class<? extends Exporter> expClass = ge.exporter();
 
-			Exporter exporter = expClass.newInstance();
+			Exporter exporter = expClass.getDeclaredConstructor().newInstance();
 
 			exporter.setExportByCanonicalName(ge.exportByCanonicalName());
 			exporter.setExportByOutAliases(ge.exportByOutAliases());
@@ -383,7 +383,7 @@ public class AndHowUtil {
 		
 		if (c != null) {
 			try {
-				return c.newInstance();
+				return c.getDeclaredConstructor().newInstance();
 			} catch (Throwable ex) {
 				//ignore
 			}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowReentrantTest.java
@@ -24,29 +24,29 @@ public class AndHowReentrantTest extends AndHowCoreTestBase {
 	public void test_1_AndHowReentrantTest_BadSample_1() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(AndHowReentrantTest_BadSample_1.class);
-		
-		try {
-			AndHow.instance(config);
-			fail("This should have blown up");
-		} catch (Throwable t) {
-			assertTrue(t.getCause() instanceof AppFatalException);
-			AppFatalException afe = (AppFatalException)t.getCause();
-			assertEquals(1, afe.getProblems().size());
-			assertTrue(afe.getProblems().get(0) instanceof ConstructionProblem.InitiationLoopException);
-		}
+
+		AndHow.setConfig(config);
+
+		ExceptionInInitializerError ex = assertThrows(ExceptionInInitializerError.class, () -> AndHow.instance());
+
+		assertTrue(ex.getCause() instanceof AppFatalException);
+		AppFatalException afe = (AppFatalException)ex.getCause();
+		assertEquals(1, afe.getProblems().size());
+		assertTrue(afe.getProblems().get(0) instanceof ConstructionProblem.InitiationLoopException);
+
 	}
 	
 	@Test
 	public void test_2_AndHowReentrantTest_OkSample_1() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(AndHowReentrantTest_OkSample_1.class);
-		
 
-			AndHow.instance(config);
+		AndHow.setConfig(config);
+		AndHow.instance();
 
-			assertEquals("onetwo", AndHowReentrantTest_OkSample_1.getSomeString());
-			assertEquals("one", AndHowReentrantTest_OkSample_1.STR_1.getValue());
-			assertEquals("two", AndHowReentrantTest_OkSample_1.STR_2.getValue());
+		assertEquals("onetwo", AndHowReentrantTest_OkSample_1.getSomeString());
+		assertEquals("one", AndHowReentrantTest_OkSample_1.STR_1.getValue());
+		assertEquals("two", AndHowReentrantTest_OkSample_1.STR_2.getValue());
 
 	}
 	
@@ -54,18 +54,16 @@ public class AndHowReentrantTest extends AndHowCoreTestBase {
 	public void test_3_AndHowReentrantTest_BadSample_2() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(AndHowReentrantTest_BadSample_2.class);
-		
-		try {
-			AndHow.instance(config);
-			fail("This should have blown up");
-		} catch (Throwable t) {
-			assertTrue(t.getCause() instanceof AppFatalException);
-			AppFatalException afe = (AppFatalException)t.getCause();
-			assertEquals(1, afe.getProblems().size());
-			assertTrue(afe.getProblems().get(0) instanceof ConstructionProblem.InitiationLoopException);
-		}
+
+		AndHow.setConfig(config);
+
+		ExceptionInInitializerError ex = assertThrows(ExceptionInInitializerError.class, () -> AndHow.instance());
+
+		assertTrue(ex.getCause() instanceof AppFatalException);
+		AppFatalException afe = (AppFatalException)ex.getCause();
+		assertEquals(1, afe.getProblems().size());
+		assertTrue(afe.getProblems().get(0) instanceof ConstructionProblem.InitiationLoopException);
+
 	}
-	
-	
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -23,6 +23,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * as a unit test.
  * <br>
  * See the AndHowSystem Test sub-project for better test coverage.
+ *
+ * When the AndHow.instance(config) method is removed, this test will need to be
+ * updated to call the private AndHow.initialize(config).
  * 
  * @author ericeverman
  */
@@ -89,6 +92,33 @@ public class AndHowTest extends AndHowCoreTestBase {
 		AndHow.instance();	//Initialize and try to get config...
 
 		assertThrows(AppFatalException.class, () -> AndHow.findConfig());
+	}
+
+	@Test
+	public void setConfigShouldReplaceConfig() {
+		AndHowConfiguration<? extends AndHowConfiguration> config1 = AndHow.findConfig();
+		AndHowConfiguration<? extends AndHowConfiguration> config2 = StdConfig.instance();
+
+		assertNotSame(config1, config2);
+
+		AndHow.setConfig(config2);	//set to config2
+		assertSame(config2, AndHow.findConfig());
+
+		AndHow.setConfig(config1);	//set back to config1
+		assertSame(config1, AndHow.findConfig());
+	}
+
+	@Test
+	public void setConfigShouldThrowAppFatalSometimes() {
+		AndHowConfiguration<? extends AndHowConfiguration> config = StdConfig.instance();
+
+		assertThrows(AppFatalException.class, () -> AndHow.setConfig(null),
+				"Cannot set to null");
+
+		AndHow.instance();	//force initialize
+
+		assertThrows(AppFatalException.class, () -> AndHow.setConfig(config),
+				"Cannot access after init");
 	}
 
 	@Test
@@ -193,11 +223,11 @@ public class AndHowTest extends AndHowCoreTestBase {
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(10), SimpleParams.INT_TEN.getValue());
+		assertEquals(10, SimpleParams.INT_TEN.getValue());
 		assertNull(SimpleParams.INT_NULL.getValue());
-		assertEquals(new Long(10), SimpleParams.LNG_TEN.getValue());
+		assertEquals(10, SimpleParams.LNG_TEN.getValue());
 		assertNull(SimpleParams.LNG_NULL.getValue());
-		assertEquals(new Double(10), SimpleParams.DBL_TEN.getValue());
+		assertEquals(10, SimpleParams.DBL_TEN.getValue());
 		assertNull(SimpleParams.DBL_NULL.getValue());
 		assertEquals(LocalDateTime.parse("2007-10-01T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertNull(SimpleParams.LDT_NULL.getValue());

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTestUtil.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTestUtil.java
@@ -104,7 +104,8 @@ public class AndHowTestUtil {
 		if (ahInstance == null) {
 
 			//This is an uninitialized AndHow instance, initialize 'normally'
-			AndHow.instance(config);
+			AndHow.setConfig(config);
+			AndHow.instance();
 
 		} else {
 			//AndHow is already initialized, so just reassign the core

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -42,15 +42,15 @@ public class AndHowUsageExampleTest extends AndHowCoreTestBase {
 				.group(UI_CONFIG.class).group(SERVICE_CONFIG.class)
 				.setCmdLineArgs(cmdLineArgsWFullClassName);
 		
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 		
 		assertEquals("My App", UI_CONFIG.DISPLAY_NAME.getValue());
 		assertEquals("ffffff", UI_CONFIG.BACKGROUP_COLOR.getValue());
 		assertEquals("google.com", SERVICE_CONFIG.REST_ENDPOINT_URL.getValue());
-		assertEquals(new Integer(4), SERVICE_CONFIG.RETRY_COUNT.getValue());
-		assertEquals(new Integer(10), SERVICE_CONFIG.TIMEOUT_SECONDS.getValue());
-		assertEquals(new Double(9.8), SERVICE_CONFIG.GRAVITY.getValue(), .00000001d);
-		assertEquals(new Double(3.14), SERVICE_CONFIG.PIE.getValue(), .00000001d);
+		assertEquals(4, SERVICE_CONFIG.RETRY_COUNT.getValue());
+		assertEquals(10, SERVICE_CONFIG.TIMEOUT_SECONDS.getValue());
+		assertEquals(9.8, SERVICE_CONFIG.GRAVITY.getValue(), .00000001d);
+		assertEquals(3.14, SERVICE_CONFIG.PIE.getValue(), .00000001d);
 	}
 	
 	@Test
@@ -60,32 +60,32 @@ public class AndHowUsageExampleTest extends AndHowCoreTestBase {
 				.addCmdLineArg(uiFullPath + "DISPLAY_NAME", "My App")
 				.addCmdLineArg(svsFullPath + "REST_ENDPOINT_URL", "yahoo.com")
 				.addCmdLineArg(svsFullPath + "TIMEOUT_SECONDS", "99");
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("My App", UI_CONFIG.DISPLAY_NAME.getValue());
 		assertNull(UI_CONFIG.BACKGROUP_COLOR.getValue());
 		assertEquals("yahoo.com", SERVICE_CONFIG.REST_ENDPOINT_URL.getValue());
-		assertEquals(new Integer(3), SERVICE_CONFIG.RETRY_COUNT.getValue());
-		assertEquals(new Integer(99), SERVICE_CONFIG.TIMEOUT_SECONDS.getValue());
+		assertEquals(3, SERVICE_CONFIG.RETRY_COUNT.getValue());
+		assertEquals(99, SERVICE_CONFIG.TIMEOUT_SECONDS.getValue());
 	}
 	
 	@Test
 	public void testMissingValuesException() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(UI_CONFIG.class).group(SERVICE_CONFIG.class);
-			
-			AndHow.instance(config);
-			
-			fail();
-		} catch (AppFatalException ce) {
-			assertEquals(3, ce.getProblems().filter(RequirementProblem.class).size());
-			assertEquals(UI_CONFIG.DISPLAY_NAME, ce.getProblems().filter(RequirementProblem.class).get(0).getPropertyCoord().getProperty());
-			assertEquals(SERVICE_CONFIG.REST_ENDPOINT_URL, ce.getProblems().filter(RequirementProblem.class).get(1).getPropertyCoord().getProperty());
-			assertEquals(SERVICE_CONFIG.TIMEOUT_SECONDS, ce.getProblems().filter(RequirementProblem.class).get(2).getPropertyCoord().getProperty());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(UI_CONFIG.class).group(SERVICE_CONFIG.class);
+
+
+			AndHow.setConfig(config);
+
+		AppFatalException ex = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		assertEquals(3, ex.getProblems().filter(RequirementProblem.class).size());
+		assertEquals(UI_CONFIG.DISPLAY_NAME, ex.getProblems().filter(RequirementProblem.class).get(0).getPropertyCoord().getProperty());
+		assertEquals(SERVICE_CONFIG.REST_ENDPOINT_URL, ex.getProblems().filter(RequirementProblem.class).get(1).getPropertyCoord().getProperty());
+		assertEquals(SERVICE_CONFIG.TIMEOUT_SECONDS, ex.getProblems().filter(RequirementProblem.class).get(2).getPropertyCoord().getProperty());
+
 	}
 	
 	public static interface UI_CONFIG {
@@ -99,8 +99,6 @@ public class AndHowUsageExampleTest extends AndHowCoreTestBase {
 		IntProp TIMEOUT_SECONDS = IntProp.builder().mustBeNonNull().build();
 		DblProp GRAVITY = DblProp.builder().mustBeGreaterThan(9.1d).mustBeLessThan(10.2d).build();
 		DblProp PIE = DblProp.builder().mustBeGreaterThanOrEqualTo(3.1).mustBeLessThanOrEqualTo(3.2).build();
-
 	}
-	
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
@@ -72,8 +72,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 				.addCmdLineArg(STR_PROP2_ALIAS, STR2)
 				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -88,8 +88,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 				.addCmdLineArg(STR_PROP2_IN_ALT1_ALIAS, STR2)
 				.addCmdLineArg(INT_PROP1_ALT_IN1_ALIAS, INT1.toString())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -103,8 +103,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 				.addCmdLineArg(STR_PROP2_IN_ALT2_ALIAS, STR2)
 				.addCmdLineArg(INT_PROP1_ALT_IN1_ALIAS, INT1.toString())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -127,8 +127,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -150,8 +150,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -174,8 +174,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -198,8 +198,8 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
@@ -213,80 +213,75 @@ public class AndHow_AliasInTest extends AndHowCoreTestBase {
 	@Test
 	public void testSingleInDuplicateOfGroup1InAlias() {
 		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
-					.addCmdLineArg(STR_PROP2_ALIAS, STR2)
-					.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
-					.group(AliasGroup1.class)
-					.group(AliasGroup2.class);
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
+				.addCmdLineArg(STR_PROP2_ALIAS, STR2)
+				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
+				.group(AliasGroup1.class)
+				.group(AliasGroup2.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
 			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(1, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup2.strProp1, nun.getBadPropertyCoord().getProperty());
-			assertEquals(STR_PROP1_IN, nun.getConflictName());
-		}
+		assertEquals(1, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup2.strProp1, nun.getBadPropertyCoord().getProperty());
+		assertEquals(STR_PROP1_IN, nun.getConflictName());
 	}
 	
 
 	@Test
 	public void testSingleInDuplicateOfGroup1InAliasInLowerCase() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
-					.addCmdLineArg(STR_PROP2_ALIAS, STR2)
-					.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
-					.group(AliasGroup1.class)
-					.group(AliasGroup4.class);
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
+				.addCmdLineArg(STR_PROP2_ALIAS, STR2)
+				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
+				.group(AliasGroup1.class)
+				.group(AliasGroup4.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
 			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(1, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup4.strProp1, nun.getBadPropertyCoord().getProperty());
-			assertEquals(STR_PROP1_IN.toLowerCase(), nun.getConflictName());
-		}
+		assertEquals(1, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup4.strProp1, nun.getBadPropertyCoord().getProperty());
+		assertEquals(STR_PROP1_IN.toLowerCase(), nun.getConflictName());
 	}
 	
 	@Test
 	public void testSingleInDuplicateOfGroup1InOutAlias() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
-					.addCmdLineArg(STR_PROP2_ALIAS, STR2)
-					.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
-					.group(AliasGroup1.class)
-					.group(AliasGroup3.class);
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
+				.addCmdLineArg(STR_PROP2_ALIAS, STR2)
+				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
+				.group(AliasGroup1.class)
+				.group(AliasGroup3.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
 			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(1, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup3.strProp1, nun.getBadPropertyCoord().getProperty());
-			assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
-		}
+		assertEquals(1, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup3.strProp1, nun.getBadPropertyCoord().getProperty());
+		assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
 	}
 	
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
@@ -91,8 +91,8 @@ public class AndHow_AliasOutTest extends AndHowCoreTestBase {
 				.addCmdLineArg(STR_PROP2_IN_ALIAS, STR2)
 				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
 				.group(AliasGroup1.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		//This just tests the test...
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
@@ -133,8 +133,8 @@ public class AndHow_AliasOutTest extends AndHowCoreTestBase {
 				.addCmdLineArg(grp2Name + ".strProp2", STR2)
 				.addCmdLineArg(grp2Name + ".intProp1", INT1.toString())
 				.group(AliasGroup2.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 	
 
 		//
@@ -160,8 +160,9 @@ public class AndHow_AliasOutTest extends AndHowCoreTestBase {
 				.addCmdLineArg(grp2Name + ".strProp1", STR1)
 				.addCmdLineArg(grp2Name + ".strProp2", STR2)
 				.addCmdLineArg(grp2Name + ".intProp1", INT1.toString());
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
+		AndHow.instance();
 		
 		//
 		// Group 1
@@ -197,76 +198,69 @@ public class AndHow_AliasOutTest extends AndHowCoreTestBase {
 
 	@Test
 	public void testSingleOutDuplicateOfGroup1InOutAlias() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
-					.addCmdLineArg(STR_PROP2_IN_ALIAS, STR2)
-					.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
-					.group(AliasGroup1.class)
-					.group(AliasGroup4.class);
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
+				.addCmdLineArg(STR_PROP2_IN_ALIAS, STR2)
+				.addCmdLineArg(INT_PROP1_ALIAS, INT1.toString())
+				.group(AliasGroup1.class)
+				.group(AliasGroup4.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
 			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(1, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup4.strProp1, nun.getBadPropertyCoord().getProperty());
-			assertEquals(AliasGroup4.class, nun.getBadPropertyCoord().getGroup());
-			assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
-		}
+		assertEquals(1, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup4.strProp1, nun.getBadPropertyCoord().getProperty());
+		assertEquals(AliasGroup4.class, nun.getBadPropertyCoord().getGroup());
+		assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
 	}
 	
 	@Test
 	public void testSingleOutDuplicateWithinASingleGroup() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(AliasGroup5.class);
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(AliasGroup5.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
 			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(1, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup5.strProp2, nun.getBadPropertyCoord().getProperty());
-			assertEquals(AliasGroup5.class, nun.getBadPropertyCoord().getGroup());
-			assertEquals(STR_PROP1_OUT_ALIAS, nun.getConflictName());
-		}
+		assertEquals(1, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup5.strProp2, nun.getBadPropertyCoord().getProperty());
+		assertEquals(AliasGroup5.class, nun.getBadPropertyCoord().getGroup());
+		assertEquals(STR_PROP1_OUT_ALIAS, nun.getConflictName());
 	}
 	
 	@Test
 	public void testTwoOutOutDuplicatesBetweenTwoGroups() {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(AliasGroup6.class)
-					.group(AliasGroup7.class);
-			
-			AndHow.instance(config);
-			
-			fail("Should have thrown an exception");
-		} catch (AppFatalException e) {
-			List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
-			assertEquals(2, probs.size());
-			assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
-			ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
-			
-			assertEquals(AliasGroup7.strProp1, nun.getBadPropertyCoord().getProperty());
-			assertEquals(AliasGroup7.class, nun.getBadPropertyCoord().getGroup());
-			assertEquals(STR_PROP1_OUT_ALIAS, nun.getConflictName());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(AliasGroup6.class)
+				.group(AliasGroup7.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
+
+		assertEquals(2, probs.size());
+		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
+		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
+
+		assertEquals(AliasGroup7.strProp1, nun.getBadPropertyCoord().getProperty());
+		assertEquals(AliasGroup7.class, nun.getBadPropertyCoord().getGroup());
+		assertEquals(STR_PROP1_OUT_ALIAS, nun.getConflictName());
 	}
-	
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
@@ -42,7 +42,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 		
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 		
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
@@ -59,7 +59,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
@@ -77,7 +77,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("  Big App  ", SampleRestClientGroup.APP_NAME.getValue());	//Just check one prop file val
 		assertEquals(99, SampleRestClientGroup.REST_PORT.getValue(), "Fixed value should override prop file");
@@ -93,7 +93,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
@@ -111,7 +111,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("  Big App  ", SampleRestClientGroup.APP_NAME.getValue());	//Just check one prop file val
 		assertEquals(98, SampleRestClientGroup.REST_PORT.getValue(), "Fixed value should override prop file");
@@ -132,7 +132,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
@@ -154,7 +154,7 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
 
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
@@ -169,10 +169,10 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 
 		assertEquals("  Big App  ", SampleRestClientGroup.APP_NAME.getValue(), failDesc);
 		assertEquals("aquarius.usgs.gov", SampleRestClientGroup.REST_HOST.getValue(), failDesc);
-		assertEquals(new Integer(8080), SampleRestClientGroup.REST_PORT.getValue(), failDesc);
+		assertEquals(8080, SampleRestClientGroup.REST_PORT.getValue(), failDesc);
 		assertEquals("doquery/", SampleRestClientGroup.REST_SERVICE_NAME.getValue(), failDesc);
 		assertEquals("abc123", SampleRestClientGroup.AUTH_KEY.getValue(), failDesc);
-		assertEquals(new Integer(4), SampleRestClientGroup.RETRY_COUNT.getValue(), failDesc);
+		assertEquals(4, SampleRestClientGroup.RETRY_COUNT.getValue(), failDesc);
 		assertFalse(SampleRestClientGroup.REQUEST_META_DATA.getValue(), failDesc);
 		assertTrue(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue(), failDesc);
 	}
@@ -189,16 +189,16 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 				.setCmdLineArgs(cmdLineArgs)
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.minimum.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
 		assertEquals("aquarius.usgs.gov", SampleRestClientGroup.REST_HOST.getValue());
-		assertEquals(new Integer(8080), SampleRestClientGroup.REST_PORT.getValue());
+		assertEquals(8080, SampleRestClientGroup.REST_PORT.getValue());
 		assertEquals("query/", SampleRestClientGroup.REST_SERVICE_NAME.getValue());	//a default value
 		assertEquals("abc123", SampleRestClientGroup.AUTH_KEY.getValue());
-		assertEquals(new Integer(2), SampleRestClientGroup.RETRY_COUNT.getValue());	//a default
+		assertEquals(2, SampleRestClientGroup.RETRY_COUNT.getValue());	//a default
 		assertTrue(SampleRestClientGroup.REQUEST_META_DATA.getValue());	//a default
 		assertFalse(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue());	//a default
 
@@ -213,44 +213,40 @@ public class StdConfigSimulatedAppTest extends AndHowCoreTestBase {
 		String[] cmdLineArgs = new String[] {
 				GROUP_PATH + ".CLASSPATH_PROP_FILE" + KVP_DELIMITER + CLASSPATH_BEGINNING + "invalid.properties"
 		};
-				
-		try {
-			
-			//Error expected b/c some values are invalid
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(SampleRestClientGroup.class)
-					.setCmdLineArgs(cmdLineArgs)
-					.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
-					.classpathPropertiesRequired();
-		
-			AndHow.instance(config);
-		
-		} catch (AppFatalException e) {
-			
-			//Value Problems (validation)
-			//Due to loading from a prop file, the order of the file is not preserved,
-			//so we cannot know the order that problems were encountered.
-			ArrayList<Property<?>> expectedProblemPoints = new ArrayList();
-			expectedProblemPoints.add(SampleRestClientGroup.REST_HOST);
-			expectedProblemPoints.add(SampleRestClientGroup.REST_PORT);
-			expectedProblemPoints.add(SampleRestClientGroup.REST_SERVICE_NAME);
-			
-			assertEquals(3, e.getProblems().filter(ValueProblem.class).size());
-			assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(0).getBadValueCoord().getProperty()));
-			assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(1).getBadValueCoord().getProperty()));
-			assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(2).getBadValueCoord().getProperty()));
-			
-			//
-			// Loader problems
-			assertEquals(1, e.getProblems().filter(LoaderProblem.class).size());
-			assertEquals(SampleRestClientGroup.RETRY_COUNT, e.getProblems().filter(LoaderProblem.class).get(0).getBadValueCoord().getProperty());
-		}
-		
+
+
+		//Error expected b/c some values are invalid
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(SampleRestClientGroup.class)
+				.setCmdLineArgs(cmdLineArgs)
+				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
+				.classpathPropertiesRequired();
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		//Value Problems (validation)
+		//Due to loading from a prop file, the order of the file is not preserved,
+		//so we cannot know the order that problems were encountered.
+		ArrayList<Property<?>> expectedProblemPoints = new ArrayList();
+		expectedProblemPoints.add(SampleRestClientGroup.REST_HOST);
+		expectedProblemPoints.add(SampleRestClientGroup.REST_PORT);
+		expectedProblemPoints.add(SampleRestClientGroup.REST_SERVICE_NAME);
+
+		assertEquals(3, e.getProblems().filter(ValueProblem.class).size());
+		assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(0).getBadValueCoord().getProperty()));
+		assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(1).getBadValueCoord().getProperty()));
+		assertTrue(expectedProblemPoints.contains(e.getProblems().filter(ValueProblem.class).get(2).getBadValueCoord().getProperty()));
+
+		//
+		// Loader problems
+		assertEquals(1, e.getProblems().filter(LoaderProblem.class).size());
+		assertEquals(SampleRestClientGroup.RETRY_COUNT, e.getProblems().filter(LoaderProblem.class).get(0).getBadValueCoord().getProperty());
 
 	}
 
 	interface SampleRestClientGroup {
-
 		StrProp CLASSPATH_PROP_FILE = StrProp.builder().desc("Classpath location of a properties file w/ props").build();
 		StrProp APP_NAME = StrProp.builder().aliasIn("app.name").aliasIn("app_name").build();
 		StrProp REST_HOST = StrProp.builder().mustMatchRegex(".*\\.usgs\\.gov") .mustBeNonNull().build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderAppTest.java
@@ -35,8 +35,7 @@ public class PropFileOnClasspathLoaderAppTest extends AndHowCoreTestBase {
 				.group(SimpleParams.class)
 				.group(TestProps.class);
 		
-		AndHow.instance(config);
-		
+		AndHow.setConfig(config);
 
 		assertEquals("/org/yarnandtail/andhow/load/SimpleParams1.properties", TestProps.CLAZZ_PATH.getValue());
 		assertEquals("kvpBobValue", SimpleParams.STR_BOB.getValue());
@@ -48,23 +47,21 @@ public class PropFileOnClasspathLoaderAppTest extends AndHowCoreTestBase {
 	
 	@Test
 	public void testInvalid() throws Exception {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH), 
-							"/org/yarnandtail/andhow/load/SimpleParamsInvalid.properties")
-					.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
-					.classpathPropertiesRequired()
-					.group(SimpleParams.class)
-					.group(TestProps.class);
-		
-			AndHow.instance(config);
-		
-				fail("The property file contains several invalid props - should have errored");
-		} catch (AppFatalException afe) {
-			List<Problem> probs = afe.getProblems();
-			assertEquals(5, probs.size());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH),
+						"/org/yarnandtail/andhow/load/SimpleParamsInvalid.properties")
+				.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
+				.classpathPropertiesRequired()
+				.group(SimpleParams.class)
+				.group(TestProps.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException afe = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<Problem> probs = afe.getProblems();
+		assertEquals(5, probs.size());
 
 	}
 	
@@ -74,30 +71,29 @@ public class PropFileOnClasspathLoaderAppTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(SimpleParams.class)
 				.group(TestProps.class);	//This must be declared or the Prop loader can't work
-		
-		AndHow.instance(config);	
 
+		AndHow.setConfig(config);
+		AndHow.instance();
 		
 		//It is OK to have a null config for the PropFile loader - it just turns it off
 	}
 	
 	@Test
 	public void testUnregisteredPropLoaderProperty() throws Exception {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH), 
-							"/org/yarnandtail/andhow/load/SimpleParams1.properties")
-					.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
-					.group(SimpleParams.class);
-					//.group(TestProps.class) //Missing - should cause failure
-			AndHow.instance(config);
-		
-			fail("The Property loader config parameter is not registered, so it should have failed");
-		} catch (AppFatalException afe) {
-			List<LoaderPropertyNotRegistered> probs = afe.getProblems().filter(LoaderPropertyNotRegistered.class);
-			assertEquals(1, probs.size());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH),
+						"/org/yarnandtail/andhow/load/SimpleParams1.properties")
+				.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
+				.group(SimpleParams.class);
+				//.group(TestProps.class) //Missing - should cause failure
+
+		AndHow.setConfig(config);
+
+		AppFatalException afe = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<LoaderPropertyNotRegistered> probs = afe.getProblems().filter(LoaderPropertyNotRegistered.class);
+		assertEquals(1, probs.size());
 	}
 	
 	/**
@@ -115,7 +111,7 @@ public class PropFileOnClasspathLoaderAppTest extends AndHowCoreTestBase {
 				.group(SimpleParams.class)
 				.group(TestProps.class);
 		
-		AndHow.instance(config);
+		AndHow.setConfig(config);
 		
 		//These are just default values
 		assertEquals("bob", SimpleParams.STR_BOB.getValue());
@@ -124,24 +120,21 @@ public class PropFileOnClasspathLoaderAppTest extends AndHowCoreTestBase {
 	
 	@Test
 	public void testABadClasspathThatDoesNotPointToAFile() throws Exception {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH), 
-							"asdfasdfasdf/asdfasdf/asdf")
-					.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
-					.classpathPropertiesRequired()
-					.group(SimpleParams.class)
-					.group(TestProps.class);
-		
-			AndHow.instance(config);
-			
-			fail("The Property loader config property is not pointing to a real file location");
-			
-		} catch (AppFatalException afe) {
-			List<SourceNotFoundLoaderProblem> probs = afe.getProblems().filter(SourceNotFoundLoaderProblem.class);
-			assertEquals(1, probs.size());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.CLAZZ_PATH),
+						"asdfasdfasdf/asdfasdf/asdf")
+				.setClasspathPropFilePath(TestProps.CLAZZ_PATH)
+				.classpathPropertiesRequired()
+				.group(SimpleParams.class)
+				.group(TestProps.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException afe = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<SourceNotFoundLoaderProblem> probs = afe.getProblems().filter(SourceNotFoundLoaderProblem.class);
+		assertEquals(1, probs.size());
 	}
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnFilesystemLoaderAppTest.java
@@ -33,13 +33,11 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 
 	@BeforeEach
 	public void init() throws Exception {
-		
 		//copy a properties file to a temp location
 		URL inputUrl = getClass().getResource("/org/yarnandtail/andhow/load/SimpleParams1.properties");
 		tempPropertiesFile = File.createTempFile("andhow_test", ".properties");
 		tempPropertiesFile.deleteOnExit();
 		FileUtils.copyURLToFile(inputUrl, tempPropertiesFile);
-
 	}
 	
 	@AfterEach
@@ -59,9 +57,8 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 				.filesystemPropFileRequired()
 				.group(SimpleParams.class)
 				.group(TestProps.class);
-		
-		AndHow.instance(config);
-		
+
+		AndHow.setConfig(config);
 
 		assertEquals(tempPropertiesFile.getAbsolutePath(), TestProps.FILEPATH.getValue());
 		assertEquals("kvpBobValue", SimpleParams.STR_BOB.getValue());
@@ -73,24 +70,20 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 	
 	@Test
 	public void testUnregisteredPropLoaderProperty() throws Exception {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.FILEPATH), 
-							tempPropertiesFile.getAbsolutePath())
-					.setFilesystemPropFilePath(TestProps.FILEPATH)
-					.filesystemPropFileRequired()
-					.group(SimpleParams.class);
-					//.group(TestProps.class)	//Missing - should fail
 
-			AndHow.instance(config);
-		
-			fail("The Property loader config parameter is not registered, so it should have failed");
-		} catch (AppFatalException afe) {
-			List<LoaderPropertyNotRegistered> probs = afe.getProblems().filter(LoaderPropertyNotRegistered.class);
-			assertEquals(1, probs.size());
-		}
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.FILEPATH),
+						tempPropertiesFile.getAbsolutePath())
+				.setFilesystemPropFilePath(TestProps.FILEPATH)
+				.filesystemPropFileRequired()
+				.group(SimpleParams.class);
+				//.group(TestProps.class)	//Missing - should fail
 
+		AndHow.setConfig(config);
+
+		AppFatalException afe = assertThrows(AppFatalException.class, () -> AndHow.instance());
+		List<LoaderPropertyNotRegistered> probs = afe.getProblems().filter(LoaderPropertyNotRegistered.class);
+		assertEquals(1, probs.size());
 	}
 	
 	/**
@@ -107,8 +100,8 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 				.filesystemPropFileRequired()
 				.group(SimpleParams.class)
 				.group(TestProps.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		//These are just default values
 		assertEquals("bob", SimpleParams.STR_BOB.getValue());
@@ -117,24 +110,20 @@ public class PropFileOnFilesystemLoaderAppTest extends AndHowCoreTestBase {
 	
 	@Test
 	public void testABadClasspathThatDoesNotPointToAFile() throws Exception {
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.FILEPATH), 
-							"asdfasdfasdf/asdfasdf/asdf")
-					.setFilesystemPropFilePath(TestProps.FILEPATH)
-					.filesystemPropFileRequired()
-					.group(SimpleParams.class)
-					.group(TestProps.class);
-		
-			AndHow.instance(config);
-			
-			fail("The Property loader config property is not pointing to a real file location");
-			
-		} catch (AppFatalException afe) {
-			List<SourceNotFoundLoaderProblem> probs = afe.getProblems().filter(SourceNotFoundLoaderProblem.class);
-			assertEquals(1, probs.size());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.addCmdLineArg(NameUtil.getAndHowName(TestProps.class, TestProps.FILEPATH),
+						"asdfasdfasdf/asdfasdf/asdf")
+				.setFilesystemPropFilePath(TestProps.FILEPATH)
+				.filesystemPropFileRequired()
+				.group(SimpleParams.class)
+				.group(TestProps.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException afe = assertThrows(AppFatalException.class, () -> AndHow.instance());
+		List<SourceNotFoundLoaderProblem> probs = afe.getProblems().filter(SourceNotFoundLoaderProblem.class);
+		assertEquals(1, probs.size());
 	}
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
@@ -87,18 +87,18 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-999), SimpleParams.INT_TEN.getValue());
-		assertEquals(new Integer(999), SimpleParams.INT_NULL.getValue());
-		assertEquals(new Long(-999), SimpleParams.LNG_TEN.getValue());
-		assertEquals(new Long(999), SimpleParams.LNG_NULL.getValue());
+		assertEquals(-999, SimpleParams.INT_TEN.getValue());
+		assertEquals(999, SimpleParams.INT_NULL.getValue());
+		assertEquals(-999, SimpleParams.LNG_TEN.getValue());
+		assertEquals(999, SimpleParams.LNG_NULL.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
@@ -123,20 +123,20 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-999), SimpleParams.INT_TEN.getValue());
-		assertEquals(new Integer(999), SimpleParams.INT_NULL.getValue());
-		assertEquals(new Long(-999), SimpleParams.LNG_TEN.getValue());
-		assertEquals(new Long(999), SimpleParams.LNG_NULL.getValue());
-		assertEquals(new Long(-999), SimpleParams.LNG_TEN.getValue());
-		assertEquals(new Long(999), SimpleParams.LNG_NULL.getValue());
+		assertEquals(-999, SimpleParams.INT_TEN.getValue());
+		assertEquals(999, SimpleParams.INT_NULL.getValue());
+		assertEquals(-999, SimpleParams.LNG_TEN.getValue());
+		assertEquals(999, SimpleParams.LNG_NULL.getValue());
+		assertEquals(-999, SimpleParams.LNG_TEN.getValue());
+		assertEquals(999, SimpleParams.LNG_NULL.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
@@ -162,16 +162,16 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/,    java:test/  ,   java:myapp/root/")
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-999), SimpleParams.INT_TEN.getValue());
-		assertEquals(new Integer(999), SimpleParams.INT_NULL.getValue());
+		assertEquals(-999, SimpleParams.INT_TEN.getValue());
+		assertEquals(999, SimpleParams.INT_NULL.getValue());
 	}
 	
 	@Test
@@ -197,15 +197,15 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 				.addFixedValue(StdJndiLoader.CONFIG.STANDARD_JNDI_ROOTS, "java:zip/,java:xy/z/")
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/  ,  ,java:test/ , java:myapp/root/")
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-999), SimpleParams.INT_TEN.getValue());
+		assertEquals(-999, SimpleParams.INT_TEN.getValue());
 		assertNull(SimpleParams.INT_NULL.getValue());
 	}
 	
@@ -224,11 +224,11 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		jndi.bind("java:comp/env/" + 
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL)), Boolean.TRUE);
 		jndi.bind("java:comp/env/" + 
-				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), new Integer(-999));
-		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), new Integer(999));
+				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), Integer.valueOf(-999));
+		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), Integer.valueOf(999));
 		jndi.bind("java:comp/env/" + 
-				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), new Long(-999));
-		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL), new Long(999));
+				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), Long.valueOf(-999));
+		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL), Long.valueOf(999));
 		jndi.bind("java:comp/env/" + 
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01)), LocalDateTime.parse("2007-11-02T00:00"));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL), LocalDateTime.parse("2007-11-02T00:00"));
@@ -237,17 +237,16 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
-		
-		
+
+		AndHow.setConfig(config);
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-999), SimpleParams.INT_TEN.getValue());
-		assertEquals(new Integer(999), SimpleParams.INT_NULL.getValue());
+		assertEquals(-999, SimpleParams.INT_TEN.getValue());
+		assertEquals(999, SimpleParams.INT_NULL.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
@@ -266,16 +265,16 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		jndi.bind("java:" + 
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), Boolean.TRUE);
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), Boolean.TRUE);
-		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), new Integer(-9999));
+		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), -9999);
 		jndi.bind("java:" + 
-				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), new Integer(9999));
+				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)),9999);
 		
 		jndi.activate();
 		
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.group(SimpleParams.class);
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
 		
 		
 		assertEquals("test2", SimpleParams.STR_BOB.getValue());
@@ -283,8 +282,8 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
 		assertEquals(true, SimpleParams.FLAG_FALSE.getValue());
 		assertEquals(true, SimpleParams.FLAG_NULL.getValue());
-		assertEquals(new Integer(-9999), SimpleParams.INT_TEN.getValue());
-		assertEquals(new Integer(9999), SimpleParams.INT_NULL.getValue());
+		assertEquals(-9999, SimpleParams.INT_TEN.getValue());
+		assertEquals(9999, SimpleParams.INT_NULL.getValue());
 	}
 	
 	//
@@ -305,22 +304,18 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 
 		jndi.activate();
 		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(SimpleParams.class);
-			
-			AndHow.instance(config);
-		
-			fail("Should not reach this point");
-			
-		} catch (AppFatalException e) {
-			List<LoaderProblem> lps = e.getProblems().filter(LoaderProblem.class);
-			
-			assertEquals(1, lps.size());
-			assertTrue(lps.get(0) instanceof LoaderProblem.DuplicatePropertyLoaderProblem);
-			
-		}
-		
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(SimpleParams.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<LoaderProblem> lps = e.getProblems().filter(LoaderProblem.class);
+
+		assertEquals(1, lps.size());
+		assertTrue(lps.get(0) instanceof LoaderProblem.DuplicatePropertyLoaderProblem);
 	}
 	
 
@@ -330,31 +325,28 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
 		
-		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), new Long(-9999));
+		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), Long.valueOf(-9999));
 		jndi.bind("java:" + 
-				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), new Float(22));
-		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), new Integer(-9999));
+				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), Float.valueOf(22));
+		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), Integer.valueOf(-9999));
 		jndi.activate();
 		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(SimpleParams.class);
-			
-			AndHow.instance(config);
-		
-			fail("Should not reach this point");
-			
-		} catch (AppFatalException e) {
-			List<LoaderProblem> lps = e.getProblems().filter(LoaderProblem.class);
-			
-			assertEquals(3, lps.size());
-			assertTrue(lps.get(0) instanceof LoaderProblem.ObjectConversionValueProblem);
-			assertEquals(SimpleParams.INT_TEN, lps.get(0).getBadValueCoord().getProperty());
-			assertTrue(lps.get(1) instanceof LoaderProblem.ObjectConversionValueProblem);
-			assertEquals(SimpleParams.INT_NULL, lps.get(1).getBadValueCoord().getProperty());
-			assertTrue(lps.get(2) instanceof LoaderProblem.ObjectConversionValueProblem);
-			assertEquals(SimpleParams.LNG_TEN, lps.get(2).getBadValueCoord().getProperty());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(SimpleParams.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+		List<LoaderProblem> lps = e.getProblems().filter(LoaderProblem.class);
+
+		assertEquals(3, lps.size());
+		assertTrue(lps.get(0) instanceof LoaderProblem.ObjectConversionValueProblem);
+		assertEquals(SimpleParams.INT_TEN, lps.get(0).getBadValueCoord().getProperty());
+		assertTrue(lps.get(1) instanceof LoaderProblem.ObjectConversionValueProblem);
+		assertEquals(SimpleParams.INT_NULL, lps.get(1).getBadValueCoord().getProperty());
+		assertTrue(lps.get(2) instanceof LoaderProblem.ObjectConversionValueProblem);
+		assertEquals(SimpleParams.LNG_TEN, lps.get(2).getBadValueCoord().getProperty());
 	}
 	
 	@Test
@@ -368,27 +360,23 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), "Apple");
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), "234.567");
 		jndi.activate();
-		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(SimpleParams.class);
-			
-			AndHow.instance(config);
-		
-			fail("Should not reach this point");
-			
-		} catch (AppFatalException e) {
-			List<LoaderProblem> vps = e.getProblems().filter(LoaderProblem.class);
-			
-			assertEquals(3, vps.size());
-			assertTrue(vps.get(0) instanceof LoaderProblem.StringConversionLoaderProblem);
-			assertEquals(SimpleParams.INT_TEN, vps.get(0).getBadValueCoord().getProperty());
-			assertTrue(vps.get(1) instanceof LoaderProblem.StringConversionLoaderProblem);
-			assertEquals(SimpleParams.INT_NULL, vps.get(1).getBadValueCoord().getProperty());
-			assertTrue(vps.get(2) instanceof LoaderProblem.StringConversionLoaderProblem);
-			assertEquals(SimpleParams.LNG_TEN, vps.get(2).getBadValueCoord().getProperty());
-		}
-	
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(SimpleParams.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<LoaderProblem> vps = e.getProblems().filter(LoaderProblem.class);
+
+		assertEquals(3, vps.size());
+		assertTrue(vps.get(0) instanceof LoaderProblem.StringConversionLoaderProblem);
+		assertEquals(SimpleParams.INT_TEN, vps.get(0).getBadValueCoord().getProperty());
+		assertTrue(vps.get(1) instanceof LoaderProblem.StringConversionLoaderProblem);
+		assertEquals(SimpleParams.INT_NULL, vps.get(1).getBadValueCoord().getProperty());
+		assertTrue(vps.get(2) instanceof LoaderProblem.StringConversionLoaderProblem);
+		assertEquals(SimpleParams.LNG_TEN, vps.get(2).getBadValueCoord().getProperty());
 	}
 	
 
@@ -403,19 +391,17 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 				bns.getUriName(NameUtil.getAndHowName(ValidParams.class, ValidParams.STR_XXX)), "YYY");
 		jndi.activate();
 		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(ValidParams.class);
-			
-			AndHow.instance(config);
-		
-			fail("Should not reach this point");
-			
-		} catch (AppFatalException e) {
-			List<Problem> vps = e.getProblems();
-			
-			assertEquals(2, vps.size());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(ValidParams.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<Problem> vps = e.getProblems();
+
+		assertEquals(2, vps.size());
 	}
 	
 	@Test
@@ -427,22 +413,18 @@ public class StdJndiLoaderTest extends AndHowCoreTestBase {
 		jndi.bind("java:" + NameUtil.getAndHowName(ValidParams.class, ValidParams.INT_TEN), "9");
 		jndi.activate();
 		
-		try {
-			AndHowConfiguration config = AndHowTestConfig.instance()
-					.group(ValidParams.class);
-			
-			AndHow.instance(config);
-		
-			fail("Should not reach this point");
-			
-		} catch (AppFatalException e) {
-			List<Problem> vps = e.getProblems();
-			
-			assertEquals(1, vps.size());
-			assertTrue(vps.get(0) instanceof ValueProblem);
-			assertEquals(ValidParams.INT_TEN, ((ValueProblem)(vps.get(0))).getBadValueCoord().getProperty());
-		}
+
+		AndHowConfiguration config = AndHowTestConfig.instance()
+				.group(ValidParams.class);
+
+		AndHow.setConfig(config);
+
+		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
+
+		List<Problem> vps = e.getProblems();
+
+		assertEquals(1, vps.size());
+		assertTrue(vps.get(0) instanceof ValueProblem);
+		assertEquals(ValidParams.INT_TEN, ((ValueProblem)(vps.get(0))).getBadValueCoord().getProperty());
 	}
-	
-	
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyTestBase.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyTestBase.java
@@ -31,8 +31,9 @@ public class PropertyTestBase extends AndHowCoreTestBase {
 				.addFixedValue(TEST_CONFIG.PROP_FILE, propFilePath)
 				.setClasspathPropFilePath(TEST_CONFIG.PROP_FILE)
 				.classpathPropertiesRequired();
-		
-		AndHow.instance(config);
+
+		AndHow.setConfig(config);
+		AndHow.instance();
 	}
 	
 	public static interface TEST_CONFIG {

--- a/andhow-testing/andhow-integration-test/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-testing/andhow-integration-test/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -44,7 +44,7 @@ public class AndHowTest {
 	public void testInstance_AndHowConfiguration() {
 		AndHowConfiguration<? extends AndHowConfiguration> config = AndHow.findConfig();
 		config.addFixedValue(MY_STR_PROP1, "val");
-		AndHow inst = AndHow.instance(config);
+		AndHow inst = AndHow.instance();
 		
 		assertEquals("val", MY_STR_PROP1.getValue());
 		assertEquals("val", inst.getValue(MY_STR_PROP1));

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowNonProductionUtil.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowNonProductionUtil.java
@@ -115,7 +115,8 @@ public class AndHowNonProductionUtil {
 		if (ahInstance == null) {
 
 			//This is an uninitialized AndHow instance, initialize 'normally'
-			AndHow.instance(config);
+			AndHow.setConfig(config);
+			AndHow.instance();
 
 		} else {
 			//AndHow is already initialized, so just reassign the core


### PR DESCRIPTION
* Add AndHow.setConfig(config)
* Lots of test cleanup for fewer warnings
* Cleaner tests using assertThrows instead of try/catch in a few places

### All Submissions:

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
