### PR TITLE
Replace deprecated maven expressions

### DIFF
--- a/andhow-core/pom.xml
+++ b/andhow-core/pom.xml
@@ -24,15 +24,15 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>andhow-shared-test-utils</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>andhow-junit5-extensions</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>andhow-multimodule-dataprocess</artifactId>
     <packaging>pom</packaging>
-	
+
     <modules>
         <module>andhow-default-behavior-test</module>
         <module>andhow-default-behavior-dep1</module>
@@ -23,9 +23,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>andhow-junit5-extensions</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #546

* Replace deprecated maven expressions `${groupId}`, `${version}` with `${project.groupId}` and `${project.version}` 

### All Submissions:

Have you checked that...
* [+] Your pull request is to the *_main_* branch
* [+] Your code is up to date with the latest code from the *_main_*
* [+] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [+] Your code does not decrease test coverage (maybe it improves coverage!!)
* [+] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
