### PR TITLE
Issue 545 fix code annotation

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHow.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHow.java
@@ -11,12 +11,12 @@ import org.yarnandtail.andhow.util.AndHowUtil;
 
 /**
  * Central AndHow singleton class.
- * 
+ *
  * This class is not directly constructed.  The primary way to configure an
  * instance is indirectly by creating a subclass of org.yarnandtail.andhow.AndHowInit.
  * At startup, AndHow discovers your AndHowInit implementation and uses it to configure
  * a single instance.
- * 
+ *
  * For cases where the application needs to accept command line arguments or
  * augment the configuration with fixed values, the configuration can have those
  * parameters added like this:
@@ -28,7 +28,7 @@ import org.yarnandtail.andhow.util.AndHowUtil;
  * then causes the AndHow instance to be built with that modified configuration.
  * The code above (or any method of AndHow initiation) can only be executed once
  * during the life of the application.
- * 
+ *
  * @author eeverman
  */
 public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
@@ -53,13 +53,13 @@ public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
 	 * The singleton instance is null until AndHow is initialized, then a singleton is created that
 	 * will live for the life of the application.
 	 * <p>
-	 * See {@Code core} for comparison.
+	 * See {@code core} for comparison.
 	 */
 	private static volatile AndHow singleInstance;
-	
+
 	/** Stack trace and other debug info about the startup & initiation of AndHow */
 	private static volatile Initialization initialization = null;
-	
+
 	/* True only during instance(AndHowConfiguration) method to detect re-entrant initialization */
 	private static volatile Boolean initializing = false;
 
@@ -97,29 +97,29 @@ public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
 					findGroups(config.getRegisteredGroups()));
 		}
 	}
-	
+
 	/**
 	 * Prior to AndHow initialization, this method finds the configuration that will be used.
 	 *
-	 * On the first call to this method, a new {@Code AndHowConfiguration} instance will be
+	 * On the first call to this method, a new {@code AndHowConfiguration} instance will be
 	 * created.  Later calls to this method prior to AndHow initialization will return that
 	 * same instance.  After AndHow is initialized this method will throw a fatal exception, since no
 	 * modification to the configuration can be made after AndHow has initialized.
 	 * <p>
-	 * The new {@Code AndHowConfiguration} is created in one of two ways:
+	 * The new {@code AndHowConfiguration} is created in one of two ways:
 	 * <ol>
-	 * <li>If there is a class implementing the {@Code AndHowInit} interface on the classpath,
+	 * <li>If there is a class implementing the {@code AndHowInit} interface on the classpath,
 	 * 	 it will be discovered and that class' {@link AndHowInit#getConfiguration()} method will be
 	 * 	 called to construct the instance.  This is an easy configuration point to configure AndHow
 	 * 	 for production or test.
-	 * <li>Otherwise, a default implementation of {@Code AndHowConfiguration} is created
+	 * <li>Otherwise, a default implementation of {@code AndHowConfiguration} is created
 	 *   and returned.
 	 * </ol>
 	 * <p>
 	 * This method provides a way to 'grab' the configuration before AndHow initialization
 	 * and make additions or customizations.  Common reasons for doing this would be:
 	 * <ul>
-	 * <li>In the {@Code main(String[] args)} method to add the command line arguments to
+	 * <li>In the {@code main(String[] args)} method to add the command line arguments to
 	 * AndHow (see code example below)
 	 * <li>To provide different configuration or modify the list Loaders based on
 	 * the entry point of the application.
@@ -400,17 +400,17 @@ public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
 	public static boolean isInitialized() {
 		return singleInstance != null && singleInstance.core != null;
 	}
-	
+
 	/**
 	 * Get the stacktrace of where AndHow was initialized.
-	 * 
+	 *
 	 * This can be useful for debugging InitiationLoopException errors or
 	 * errors caused by trying to initialize AndHow when it is already initialized.
 	 * This stacktrace identifies the point in code that caused the initial
 	 * AndHow initialization, prior to the error.  The reported exception will
 	 * point to the place where AndHow entered a loop during its construction
 	 * or application code attempted to re-initialize AndHow.
-	 * 
+	 *
 	 * @return A stacktrace if it is available (some JVMs may not provide one)
 	 * or an empty stacktrace array if it is not available or AndHow is not
 	 * yet initialized.
@@ -486,7 +486,7 @@ public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
 
 	/**
 	 * Encapsulate when and where AndHow was initialized.
-	 * 
+	 *
 	 * Useful for debugging re-entrant startups or uncontrolled startup conditions.
 	 * There is no API access to the instance created of this class,
 	 * it is intended to be viewed in an IDE debugger.
@@ -495,7 +495,7 @@ public class AndHow implements StaticPropertyConfiguration, ValidatedValues {
 		private final StackTraceElement[] stackTrace;
 		private final long timeStamp;
 		private final AndHowConfiguration<? extends AndHowConfiguration> config;
-		
+
 		public Initialization(AndHowConfiguration<? extends AndHowConfiguration> config) {
 			timeStamp = System.currentTimeMillis();
 			StackTraceElement[] ste = new Exception().getStackTrace();

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
@@ -40,7 +40,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * @return The strategy to use.  Must not be null.
 	 */
 	NamingStrategy getNamingStrategy();
-	
+
 	/**
 	 * Sets the command line arguments, removing any previously set commandline args.
 	 *
@@ -48,8 +48,8 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * @return
 	 */
 	C setCmdLineArgs(String[] commandLineArgs);
-	
-	
+
+
 	/**
 	 * Sets a fixed, non-configurable value for a Property.
 	 *
@@ -67,7 +67,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * @return
 	 */
 	<T> C addFixedValue(Property<T> property, T value);
-	
+
 	/**
 	 * Removes a Property value set <em>only</em> via addFixedValue(Property<T>, T value)
 	 * from the list of fixed values.
@@ -114,9 +114,9 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 
 	/**
 	 * Sets the classpath path to a properties file for the
-	 * {@Code StdPropFileOnClasspathLoader} to read and load from.
+	 * {@code StdPropFileOnClasspathLoader} to read and load from.
 	 *
-	 * If no path is specified via one of the two {@Code setClasspathPropFilePath} methods,
+	 * If no path is specified via one of the two {@code setClasspathPropFilePath} methods,
 	 * the default classpath of '/andhow.properties' is used.
 	 * <p>
 	 * As per Java convention, a path on the classpath can use dots or slashes to separate packages.
@@ -138,16 +138,16 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 
 	/**
 	 * Sets the classpath path via a StrProp (a Property of String type) to a
-	 * properties file for the {@Code StdPropFileOnClasspathLoader} to read and load from.
+	 * properties file for the {@code StdPropFileOnClasspathLoader} to read and load from.
 	 *
-	 * If no path is specified via one of the two {@Code setClasspathPropFilePath} methods,
+	 * If no path is specified via one of the two {@code setClasspathPropFilePath} methods,
 	 * the default classpath of '/andhow.properties' is used.
 	 * <p>
 	 * As per Java convention, a path on the classpath can use dots or slashes to separate packages.
 	 * However, if the file name itself contains dots, then the path must start with a slash and use
 	 * slashes to separate packages.  Its common to have a '.properties' extension on the properties
 	 * file, so its good practice to add a validation rule to the StrProp used here to ensure it
-	 * {@Code mustStartWith("/")}.
+	 * {@code mustStartWith("/")}.
 	 * <p>
 	 * Valid Examples of configured values:
 	 * <ul>
@@ -164,13 +164,13 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 
 	/**
 	 * If called to set this to 'required', a classpath properties file must
-	 * exist and be readable.  This flag is used by the {@Code StdPropFileOnClasspathLoader}.
+	 * exist and be readable.  This flag is used by the {@code StdPropFileOnClasspathLoader}.
 	 *
-	 * Since the {@Code StdPropFileOnClasspathLoader} has a default property file name,
-	 * {@Code /andhow.properties}, setting this to 'required' means that either that
+	 * Since the {@code StdPropFileOnClasspathLoader} has a default property file name,
+	 * {@code /andhow.properties}, setting this to 'required' means that either that
 	 * default file name or another that you configure instead must exist.
 	 *
-	 * @See setClasspathPropFilePath methods for details on using a non-default
+	 * @see #setClasspathPropFilePath methods for details on using a non-default
 	 * classpath properties file.
 	 *
 	 * A RuntimeException will be thrown if this is set to 'required' and there
@@ -185,7 +185,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	/**
 	 * Sets the properties file on the classpath to be optional, the default.
 	 *
-	 * @See classpathPropertiesRequired
+	 * @see #classpathPropertiesRequired
 	 *
 	 * @return
 	 */
@@ -211,13 +211,13 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	/**
 	 * If called to set this to 'required', a non-null configured value for the
 	 * filesystem properties file must point to an existing, readable properties
-	 * file.  This flag is used by the {@Code StdPropFileOnFilesystemLoader}.
+	 * file.  This flag is used by the {@code StdPropFileOnFilesystemLoader}.
 	 *
 	 * A RuntimeException will be thrown if this is set to 'required' and there
 	 * is a path specified which points to a file that does not exist.
 	 * Configuring a filesystem path is a two step process:<ul>
 	 * <li>First, a StrProp Property must be specified for this configuration
-	 * via the {@Code setFilesystemPropFilePath} method</li>
+	 * via the {@code setFilesystemPropFilePath} method</li>
 	 * <li>Then, a value must be configured for in an any way that AndHow
 	 * reads and loads values, such as environment vars, system properties, etc..</li>
 	 * </ul>
@@ -233,7 +233,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	/**
 	 * Sets the properties file on the filesystem to be optional, the default.
 	 *
-	 * @See setFilesystemPropFilePath
+	 * @see #setFilesystemPropFilePath
 	 *
 	 * @return
 	 */
@@ -244,7 +244,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 
 	/**
 	 * The default list of standard loaders, as a list of Classes that implement
-	 * {@Code StandardLoader}
+	 * {@code StandardLoader}
 	 * <p>
 	 * The returned list is disconnected from the actual list of loaders - it is
 	 * intended to be a starting point for applications that want to modify the
@@ -253,7 +253,7 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * Unlike other methods of this class, it does not fluently return a method
 	 * to itself, so your code will need a AndHowConfiguration instance reference to
 	 * use it, eg:
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * public class MyAppInitiation implements AndHowInit {
 	 *    @Override
 	 *  	public AndHowConfiguration getConfiguration() {
@@ -286,8 +286,8 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * AndHow initialization is a one-time event, so further changes to this configuration will
 	 * have no effect and additional calls to build() will throw runtime exceptions.
 	 *
-	 * @See org.yarnandtail.andhow.AndHow#instance
-	 * @See org.yarnandtail.andhow.AndHow#initialize
+	 * @see org.yarnandtail.andhow.AndHow#instance
+	 * @see org.yarnandtail.andhow.AndHow#initialize
 	 * @deprecated This method will be removed in the next major release.
 	 * Use AndHow.instance() or AndHow.initialize()
 	 */

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowConfiguration.java
@@ -253,18 +253,20 @@ public interface AndHowConfiguration<C extends AndHowConfiguration> {
 	 * Unlike other methods of this class, it does not fluently return a method
 	 * to itself, so your code will need a AndHowConfiguration instance reference to
 	 * use it, eg:
-	 * <pre>{@code
+	 * <pre>
+	 *     <code>
 	 * public class MyAppInitiation implements AndHowInit {
-	 *    @Override
+	 *    {@literal @}Override
 	 *  	public AndHowConfiguration getConfiguration() {
 	 * 			AndHowConfiguration config = AndHow.findConfig();
-	 * 			List<Class<? extends StandardLoader>> sll = config.getDefaultLoaderList();
+	 * 			{@code List<Class<? extends StandardLoader>> sll = config.getDefaultLoaderList();}
 	 * 			...do some rearranging of the list...
 	 *
 	 * 			config.setStandardLoaders(sll) ...and go on to call other methods on config...
 	 * 		}
 	 * }
-	 * }</pre>
+	 *     </code>
+	 * </pre>
 	 * <p>
 	 * Note:  AndHow version up to and including 0.4.1 had this method as a static
 	 * method.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowTestInit.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/AndHowTestInit.java
@@ -9,10 +9,12 @@ package org.yarnandtail.andhow;
  * it will be used in preference to {@code AndHowInit} to allow a test configuration to take
  * precedence over the production configuration.  Implementation example, where config values
  * for a local test db are hardcoded into the configuration:
- * <p><pre>{@code
+ * <p>
+ * <pre>
+ *     <code>
  * public class TestInitiation implements AndHowTestInit {
  *
- *  @Override
+ *  {@literal @}Override
  *  public AndHowConfiguration getConfiguration() {
  * 		return AndHow.findConfig()
  * 				.addFixedValue("com.bigcorp.config.DB_URL", "jdbc://local.db")
@@ -20,7 +22,9 @@ package org.yarnandtail.andhow;
  *  }
  *
  * }
- * }</pre><p>
+ *     </code>
+ * </pre>
+ * <p>
  * It is a fatal RuntimeException for there to be more than one {@code AndHowTestInit} on the
  * classpath since this would make startup configuration ambiguous.
  *

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/StdConfig.java
@@ -10,21 +10,21 @@ import org.yarnandtail.andhow.util.TextUtil;
  * @author ericeverman
  */
 public class StdConfig {
-	
+
 	public static StdConfigImpl instance() {
 		return new StdConfigImpl();
 	}
-	
+
 	/**
 	 * Final class 'closes' the generics for an actual implementation.
 	 */
 	public static final class StdConfigImpl extends StdConfigAbstract<StdConfigImpl> {
-		
+
 	}
-	
+
 	/**
 	 * Abstract class here lets this be extended maintaining the generic types
-	 * @param <S> 
+	 * @param <S>
 	 */
 	public static abstract class StdConfigAbstract<S extends StdConfigAbstract<S>> extends BaseConfig<S> {
 
@@ -173,16 +173,16 @@ public class StdConfig {
 
 		/**
 		 * Sets the System environment vars that AndHow will use to load Property values
-		 * from for the {@Code StdEnvVarLoader} loader.
+		 * from for the {@code StdEnvVarLoader} loader.
 		 *
 		 * If this method is not called or is called with a null Map, the actual env vars
-		 * from {@Code System.getenv()} will be used.  Calling this method with an empty
+		 * from {@code System.getenv()} will be used.  Calling this method with an empty
 		 * Map will effectively prevent AndHow from receiving configuration from env vars.
 		 *
 		 * <em></em>This does not actually change actual environment variables or what is
-		 * returned from {@Code System.getenv()}. It only replaces what AndHow will see for env vars.
+		 * returned from {@code System.getenv()}. It only replaces what AndHow will see for env vars.
 		 *
-		 * Note: There is no reason to use this method:  Use one of the {@Code addFixedValue()}
+		 * Note: There is no reason to use this method:  Use one of the {@code addFixedValue()}
 		 * methods instead.  Those methods are more clear, don't have to parse values, and
 		 * (unlike this method) are not deprecated.
 		 *
@@ -252,7 +252,7 @@ public class StdConfig {
 
 			return (S) this;
 		}
-	
+
 	}
-	
+
 }

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnClasspathLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdPropFileOnClasspathLoader.java
@@ -8,7 +8,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * Parses and loads Properties from a Java {@code .property} file on the
  * <em>classpath</em>. By default, this loader will look for a file named
  * {@code andhow.properties} at the root of the classpath.
- * 
+ *
  * <h3>Position in Standard Loading Order, first to last</h3>
  * <ul>
  * <li>StdFixedValueLoader
@@ -37,7 +37,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * <h3>Loader Details and Configuration</h3>
  * This loader reads properties files using the {@code java.util.Properties},
  * which silently ignores duplicate property entries
- * (i.e., the same key appearing multiple times).  When there are duplicate 
+ * (i.e., the same key appearing multiple times).  When there are duplicate
  * property keys in a properties file, only the last assigned value is used.
  * Full details on how Java parses properties files can be found in the
  * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-">properties file specification</a>.
@@ -49,7 +49,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * <p>
  * To change the name of the properties file used for testing, a class like the
  * example below can be added to your test classpath:
- * <pre>{@Code
+ * <pre>{@code
  * import org.yarnandtail.andhow.*;
  * import org.yarnandtail.andhow.property.StrProp;
  *
@@ -62,7 +62,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  *   }
  * }
  * }</pre>
- * If AndHow finds a {@Code AndHowTestInit} implementation on the classpath,
+ * If AndHow finds a {@code AndHowTestInit} implementation on the classpath,
  * it uses it in preference to other initiation points.
  * With this only on the test classpath, AndHow will still use the default
  * {@code andhow.properties} for production.
@@ -74,15 +74,15 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * a Property to configure it with, then we tell AndHow which property was
  * used.<br>
  * Here is an example of a configurable classpath:
- * <pre>{@Code
+ * <pre>{@code
  * import org.yarnandtail.andhow.*;
  * import org.yarnandtail.andhow.property.StrProp;
- * 
+ *
  * public class UsePropertyFileOnClasspath implements AndHowInit {
  *   public static final StrProp MY_CLASSPATH = StrProp.builder()
  *	   .desc("Path to a properties file on the classpath. "
  *       + "If the file is not present, it is not considered an error.").build();
- * 
+ *
  *   {@literal @}Override
  *   public AndHowConfiguration getConfiguration() {
  *     return  StdConfig.instance()
@@ -91,7 +91,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * }
  * }</pre>
  * The code above adds the property {@code MY_CLASSPATH}
- * (the name is arbitrary) which is used to configure the 
+ * (the name is arbitrary) which is used to configure the
  * {@code StdPropFileOnClasspathLoader} with a custom property file location.
  * When AndHow initializes, the {@code StdPropFileOnClasspathLoader} checks to
  * see if a value has been loaded for {@code MY_CLASSPATH} by any prior loader.
@@ -100,7 +100,7 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  * Properties file loaders are the last loaders, so configuration the classpath
  * can be done by virtually anything: environment vars, system properties,
  * command line args, JNDI...
- * 
+ *
  * <h3>This is a Standard Loader</h3>
  * Like all {@code StandardLoader}'s, this loader is intended to be auto-created
  * by AndHow.  The set of standard loaders and their order can bet set
@@ -111,11 +111,11 @@ import org.yarnandtail.andhow.load.PropFileOnClasspathLoader;
  *
  * @author eeverman
  */
-public class StdPropFileOnClasspathLoader extends PropFileOnClasspathLoader 
+public class StdPropFileOnClasspathLoader extends PropFileOnClasspathLoader
 		implements StandardLoader {
 
 	public static final String DEFAULT_PROP_FILE = "/andhow.properties";
-	
+
 	/**
 	 * There is no reason to use the constructor in production application code
 	 * because AndHow creates a single instance on demand at runtime.

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/EnableJndiForThisTestClass.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/EnableJndiForThisTestClass.java
@@ -47,7 +47,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test class is the same as using
- * {@Code @ExtendWith(EnableJndiForThisTestClassExt.class)} on a class, but this annotation is
+ * {@code @ExtendWith(EnableJndiForThisTestClassExt.class)} on a class, but this annotation is
  * safer because it blocks placement on a method.
  */
 @Target({ TYPE, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/EnableJndiForThisTestMethod.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/EnableJndiForThisTestMethod.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test method is the same as using
- * {@Code @ExtendWith(EnableJndiForThisTestExt.class)} on a method, but this annotation is
+ * {@code @ExtendWith(EnableJndiForThisTestExt.class)} on a method, but this annotation is
  * safer because it blocks placement on a class.
  */
 @Target({ METHOD, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeAllTests.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeAllTests.java
@@ -34,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test class is the same as using
- * {@Code @ExtendWith(KillAndHowBeforeAllTestsExtension.class)} on a class, but this annotation is
+ * {@code @ExtendWith(KillAndHowBeforeAllTestsExtension.class)} on a class, but this annotation is
  * safer because it blocks placement on a method.
  */
 @Target({ TYPE, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeEachTest.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeEachTest.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test class is the same as using
- * {@Code @ExtendWith(KillAndHowBeforeEachTestExtension.class)} on a class, but this annotation is
+ * {@code @ExtendWith(KillAndHowBeforeEachTestExtension.class)} on a class, but this annotation is
  * safer because it blocks placement on a method.
  */
 @Target({ TYPE, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeThisTest.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/KillAndHowBeforeThisTest.java
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test method is the same as using
- * {@Code @ExtendWith(KillAndHowBeforeThisTestExtension.class)} on a method, but this annotation is
+ * {@code @ExtendWith(KillAndHowBeforeThisTestExtension.class)} on a method, but this annotation is
  * safer because it blocks placement on a class.
  */
 @Target({ METHOD, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/RestoreSysPropsAfterEachTest.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/RestoreSysPropsAfterEachTest.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  * <p>
  * Note:  Using this annotation on a JUnit test class is the same as using
- * {@Code @ExtendWith(RestoreSysPropsAfterEachTestExt.class)} on a class, but this annotation is
+ * {@code @ExtendWith(RestoreSysPropsAfterEachTestExt.class)} on a class, but this annotation is
  * safer because it blocks placement on a method.
  */
 @Target({ TYPE, ANNOTATION_TYPE })

--- a/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/RestoreSysPropsAfterThisTest.java
+++ b/andhow-junit5-extensions/src/main/java/org/yarnandtail/andhow/junit5/RestoreSysPropsAfterThisTest.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * which will restore changes made in those pre-test methods.
  * <p>
  * Note:  Using this annotation on a JUnit test class is the same as using
- * {@Code @ExtendWith(RestoreSysPropsAfterEachTestExt.class)} on a class, but this annotation is
+ * {@code @ExtendWith(RestoreSysPropsAfterEachTestExt.class)} on a class, but this annotation is
  * safer because it blocks placement on a method.
  */
 @Target({ METHOD, ANNOTATION_TYPE })

--- a/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
@@ -3,10 +3,10 @@ package com.bigcorp;
 import org.yarnandtail.andhow.property.StrProp;
 
 /**
- * A simple calculator that can use two different modes, which an AndHow {@Code StrProp} allows
+ * A simple calculator that can use two different modes, which an AndHow {@code StrProp} allows
  * selection of based on configuration from (in this case) a properties file.
  *
- * This isn't a complete application, but its easy to imagine {@Code doCalc} being called by an
+ * This isn't a complete application, but its easy to imagine {@code doCalc} being called by an
  * AWS Lambda function, part of a command line utility, or just some library part of a larger app.
  */
 public class Calculator {
@@ -50,25 +50,25 @@ public class Calculator {
 	 * <p>
 	 * To run from command line, first use Maven to create a runnable jar.
 	 * Here are the commands, executed from the root of the AndHow project, to build and run the jar:<br>
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * > mvn clean package -DskipTests -Dmaven.javadoc.skip=true
 	 * > java -jar andhow-testing/andhow-simulated-app-tests/example-app-1/target/app.jar 1.23 4.56
 	 * }</pre>
 	 * The output of running this command will be:
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * Result is 0.26973684210526316 (Double)
 	 * }</pre>
-	 * How did it know to use the Double implementation?  AndHow finds the {@Code checker.production.properties}
-	 * file on the classpath and reads the configured value for CALC_MODE.  {@CODE CALC_MODE.getValue()}
+	 * How did it know to use the Double implementation?  AndHow finds the {@code checker.production.properties}
+	 * file on the classpath and reads the configured value for CALC_MODE.  {@code CALC_MODE.getValue()}
 	 * returns 'DOUBLE'.  Compare this to the unit test for this class...
 	 * <p>
 	 * Properties files are just one way AndHow reads configuration.  Values in the properties file
 	 * could be overwritten via env. vars., JNDI, system properties, etc..
 	 * Rerunning the main method with a system property like this:
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * > java -Dcom.bigcorp.Calculator.CALC_MODE=FLOAT -jar andhow-testing/andhow-simulated-app-tests/example-app-1/target/app.jar 1.23 4.56
 	 * }</pre>
-	 * will result in {@Code Result is 0.26973686 (Float)}
+	 * will result in {@code Result is 0.26973686 (Float)}
 	 *
 	 * @param args Two arguments that are parsable to numbers.
 	 */

--- a/andhow-testing/andhow-simulated-app-tests/example-app-1/src/test/java/com/bigcorp/CalculatorDefaultTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-1/src/test/java/com/bigcorp/CalculatorDefaultTest.java
@@ -7,14 +7,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * In the test environment, the application is configured to use the 'FLOAT'
- * implementation, as configured in the {@Code andhow.properties} on the TEST CLASSPATH.
+ * implementation, as configured in the {@code andhow.properties} on the TEST CLASSPATH.
  *
  * Resources on the test classpath override the main classpath, so this is a natural and useful
  * outcome.  Just like in production, AndHow will auto-discover its configuration during testing.
  * <p>
- * Using the test {@Code andhow.properties} file, however, means that all the tests run with the
+ * Using the test {@code andhow.properties} file, however, means that all the tests run with the
  * same 'FLOAT' configuration value.  How do we test the application with the DOUBLE configuration?
- * See {@Code CalculatorDoubleConfigTest} for the answer...
+ * See {@code CalculatorDoubleConfigTest} for the answer...
  * <p>
  * ...and much more flexible and complex configuration is possible for production and testing -
  * be sure to look at other of the 'simulated-app-tests'.

--- a/andhow-testing/andhow-simulated-app-tests/example-app-1/src/test/java/com/bigcorp/CalculatorDoubleConfigTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-1/src/test/java/com/bigcorp/CalculatorDoubleConfigTest.java
@@ -7,14 +7,14 @@ import org.yarnandtail.andhow.junit5.KillAndHowBeforeEachTest;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * {@Code CalculatorDefaultTest} didn't fully test the app because only some code is executed in the
+ * {@code CalculatorDefaultTest} didn't fully test the app because only some code is executed in the
  * FLOAT configuration.  This test demos testing other configurations.
  * <p>
- * The {@Code @KillAndHowBeforeEachTest} annotation erases the configured state of AndHow before
+ * The {@code @KillAndHowBeforeEachTest} annotation erases the configured state of AndHow before
  * each test so each test can specify its own AndHow configuration.  If a test doesn't explicitly
  * initialize AndHow, AndHow will initialize normally as soon as the first Property value is referenced.
  * <p>
- * When all tests are complete, {@Code KillAndHowBeforeEachTest} resets the AndHow state
+ * When all tests are complete, {@code KillAndHowBeforeEachTest} resets the AndHow state
  * back to what it was at the start of the test.
  */
 @KillAndHowBeforeEachTest  // <-- Uses the JUnit extension mechanism
@@ -37,7 +37,7 @@ class CalculatorDoubleConfigTest {
 	/**
 	 * If the test method doesn't initialize AndHow, AndHow will initialize automatically as soon
 	 * as a Property is accessed and load the default configuration from the test
-	 * {@Code checker.production.properties} file.
+	 * {@code checker.production.properties} file.
 	 */
 	@Test
 	public void revertToDefaultConfigIfTheTestDoesNotInitializeAndHow() {

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
@@ -8,7 +8,7 @@ import org.yarnandtail.andhow.property.StrProp;
  * A hypothetical class that checks if a configured service url is 'live'.
  * The url of the external service is configured by AndHow properties.
  * <p>
- * Of course, this isn't a complete application, but its easy to imagine {@Code doCheck} being
+ * Of course, this isn't a complete application, but its easy to imagine {@code doCheck} being
  * called by an AWS Lambda function, as a command line utility, or as just a library in a larger app.
  */
 public class Checker {
@@ -43,7 +43,7 @@ public class Checker {
 	/**
 	 * A main method to run this app as it might be in a real environment.
 	 * <p>
-	 * In this main method the {@Code AndHow.findConfig()} method is used to append the cmd line
+	 * In this main method the {@code AndHow.findConfig()} method is used to append the cmd line
 	 * arguments to the AndHow configuration.  This allows Property values to be configured from
 	 * these arguments, in addition to all the other way they could be configured.
 	 * <p>>
@@ -51,19 +51,19 @@ public class Checker {
 	 * <p>
 	 * To run from command line, first use Maven to create a runnable jar.
 	 * Here are the commands, executed from the root of the AndHow project, to build and run the jar:<br>
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * > mvn clean package -DskipTests -Dmaven.javadoc.skip=true
 	 * > java -jar andhow-testing/andhow-simulated-app-tests/example-app-2/target/app.jar
 	 * }</pre>
-	 * The output of this command will match the config in {@Code checker.default.properties}:
-	 * <pre>{@Code
+	 * The output of this command will match the config in {@code checker.default.properties}:
+	 * <pre>{@code
 	 * Service url: https://default.bigcorp.com:80/validate
 	 * }</pre>
 	 *
-	 * <pre>{@Code
+	 * <pre>{@code
 	 * > java -Dcom.bigcorp.Calculator.CALC_MODE=FLOAT -jar andhow-testing/andhow-simulated-app-tests/example-app-2/target/app.jar 1.23 4.56
 	 * }</pre>
-	 * will result in {@Code Result is 0.26973686 (Float)}
+	 * will result in {@code Result is 0.26973686 (Float)}
 	 *
 	 * @param args Two arguments that are parsable to numbers.
 	 */

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/test/java/com/bigcorp/CheckerDefaultAndMainArgsTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/test/java/com/bigcorp/CheckerDefaultAndMainArgsTest.java
@@ -11,7 +11,7 @@ public class CheckerDefaultAndMainArgsTest {
 	/**
 	 * Verify the the app sees its default configuration.
 	 * <p>
-	 * In the {@Code AppInitialtion.ANDHOW_CLASSPATH_FILE} Property, the default value is
+	 * In the {@code AppInitialtion.ANDHOW_CLASSPATH_FILE} Property, the default value is
 	 * 'checker.default.properties'.  In that same class we also tell AndHow to use the value of that
 	 * Property to decide which property file to use, thus property values are read from
 	 * 'checker.default.properties'.
@@ -27,13 +27,13 @@ public class CheckerDefaultAndMainArgsTest {
 	}
 
 	/**
-	 * Since the main method calls {@Code AndHow.findConfig()...build()}, forcing AndHow to build and
+	 * Since the main method calls {@code AndHow.findConfig()...build()}, forcing AndHow to build and
 	 * initialize itself, we <em>must 'kill'</em> the AndHow configured state before calling main.
 	 * Otherwise AndHow would throw a RuntimeException.
 	 * <p></p>
 	 * In production, its AndHow's job to enforce a single, stable configuration state and it complains
 	 * loudly if application code tries to re-initialize it.  During testing, however, we need to
-	 * 'break the rules' with things like {@Code @KillAndHowBeforeThisTest} and other AndHow test
+	 * 'break the rules' with things like {@code @KillAndHowBeforeThisTest} and other AndHow test
 	 * helpers.
 	 * @throws Exception
 	 */
@@ -50,11 +50,11 @@ public class CheckerDefaultAndMainArgsTest {
 	}
 
 	/**
-	 * The main method includes {@Code AndHow.findConfig().setCmdLineArgs(args)...} to allow AndHow
+	 * The main method includes {@code AndHow.findConfig().setCmdLineArgs(args)...} to allow AndHow
 	 * to process the main args.
 	 * <p>
 	 * This test shows how a key=value pair can be passed as an argument to main.  Looking at the
-	 * code in {@Code AppInitiation}, the key matches the {@Code ANDHOW_CLASSPATH_FILE} Property we
+	 * code in {@code AppInitiation}, the key matches the {@code ANDHOW_CLASSPATH_FILE} Property we
 	 * told AndHow to use to decide which file to read.  To make it easier to specify that Property,
 	 * we added the alias 'AH_CLASSPATH' so we don't need to use the full class name of that Property.
 	 * @throws Exception

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/test/java/com/bigcorp/CheckerFixedValuesTest.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/test/java/com/bigcorp/CheckerFixedValuesTest.java
@@ -15,9 +15,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * We could do that with a separate properties file, but another way is to configure AndHow with
  * 'fixed values' right in a test.
  * <p>
- * The {@Code @KillAndHowBeforeAllTests} annotation resets AndHow before the start of testing and
+ * The {@code @KillAndHowBeforeAllTests} annotation resets AndHow before the start of testing and
  * restores it after all tests are complete.  The setup method uses
- * {@Code AndHow.findConfig()...build()} to initialize AndHow with several 'fixed values' for the
+ * {@code AndHow.findConfig()...build()} to initialize AndHow with several 'fixed values' for the
  * test scenario.  The AndHow state is not modified between tests, so all tests share the same
  * AndHow configuration state.
  */
@@ -66,7 +66,7 @@ public class CheckerFixedValuesTest {
 	 * re-initializing AndHow.  This test verifies that.
 	 * <p>
 	 * The main() method explicitly initializes AndHow and so does this test class.  Thus, the main
-	 * method will throw a {@Code AppFatalException} because AndHow detects the attempt to
+	 * method will throw a {@code AppFatalException} because AndHow detects the attempt to
 	 * reinitialize it.
 	 * <p>
 	 * If we did want to call the main method here, @{Code @KillAndHowBeforeThisTest} could be added

--- a/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBase.java
+++ b/andhow-testing/andhow-test-harness/src/main/java/org/yarnandtail/andhow/AndHowTestBase.java
@@ -16,7 +16,7 @@ import org.junit.*;
  * since the use of this base class is no longer the preferred way to do testing) :
  * <a href="https://github.com/eeverman/andhow/blob/andhow-0.4.1/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/test/java/com/dep1/EarthMapMakerUsingAHBaseTestClassTest.java#L25">
  *
- * @depricated Switch to JUnit5 and the annotations in the {@link org.yarnandtail.andhow.junit5}
+ * @deprecated Switch to JUnit5 and the annotations in the {@link org.yarnandtail.andhow.junit5}
  * package, which is better, safer and easier to use.
  */
 @Deprecated


### PR DESCRIPTION
Fixes #545

* Fixe Javadocs annotations
```
@Code,@CODE => @code
@See        => @see
@depricated => @deprecated
```
* Fixe Javadocs with special charracters inside `<pre>{@code}` tag

### All Submissions:

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
