### PR TITLE
Deprecated & remove bulk export partial implementation

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/api/ExportGroup.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/api/ExportGroup.java
@@ -2,8 +2,7 @@ package org.yarnandtail.andhow.api;
 
 /**
  * Bundles an exporter and a Group for it to export.
- * 
- * Exporters that have no group (null) are intended to export everything.
+ *
  */
 public class ExportGroup {
 	private Exporter exporter;

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/api/Exporter.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/api/Exporter.java
@@ -3,18 +3,14 @@ package org.yarnandtail.andhow.api;
 import org.yarnandtail.andhow.internal.StaticPropertyConfigurationInternal;
 
 /**
- * The Exporter provides support for legacy applications that expect
- * to find key/value pairs in a specific source, such as system properties.
- * 
- * This allows applications to use AndHow for configuration and still
- maintain compatibility with legacy modules/libraries.  New code can begin to
- use the direct Property access that AndHow provides.
- 
- Exporting is considered 'safe', so overlapping export configuration, such
- as application level and Group level are read permissively.
- * 
- * 
- * @author ericeverman
+ * An Exporter exports property names and values for classes that are annotated with
+ * {@link org.yarnandtail.andhow.GroupExport}.
+ * <p>
+ * An example is the {@link org.yarnandtail.andhow.export.SysPropExporter}, which exports
+ * properties to System.Properties.
+ * <p>
+ * Exporters are passed the list Properties contained directly in the annotated class,
+ * not Properties contained in nested inner classes.
  */
 public interface Exporter {
 	
@@ -32,16 +28,22 @@ public interface Exporter {
 	
 	
 	/**
-	 * Exports all properties.
+	 * At one time, this was an 'export all properties' feature, however, it was never fully
+	 * implemented and would have broken the application security model.
 	 * 
-	 * Based on its configuration, an exporter can decide which
-	 * properties should be exported and what name or aliases should be used
-	 * when exporting.
-	 * 
+	 * Subclasses can safely not implement it and rely on the no-op default implementation
+	 * here.  If a subclass does implement it, the AndHow system will never call it.
+	 * This method will be removed from this interface in the next major release.
+	 *
+	 * @deprecated This method violates the security and was never actually called by the
+	 * system.  Removing with no replacement.
 	 * @param definition
 	 * @param values
 	 */
-	void export(StaticPropertyConfigurationInternal definition, ValidatedValues values);
+	@Deprecated
+	default void export(StaticPropertyConfigurationInternal definition, ValidatedValues values) {
+		return;
+	}
 	
 	/**
 	 * Exports a Group.

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/export/BaseExporter.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/export/BaseExporter.java
@@ -46,14 +46,6 @@ public abstract class BaseExporter implements Exporter {
 	 */
 	public abstract <T> void doExport(String name, Property<T> property, 
 			StaticPropertyConfigurationInternal definition, ValidatedValues values);
-		
-	
-	@Override
-	public void export(StaticPropertyConfigurationInternal definition, ValidatedValues values) {
-		for (GroupProxy pg : definition.getPropertyGroups()) {
-			export(pg, definition, values);
-		}
-	}
 
 	@Override
 	public void export(GroupProxy group, StaticPropertyConfigurationInternal definition, ValidatedValues values) {

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/internal/AndHowCore.java
@@ -96,17 +96,9 @@ public class AndHowCore implements StaticPropertyConfigurationInternal, Validate
 		
 		//Export Values if applicable
 		List<ExportGroup> exportGroups = staticConfig.getExportGroups();
+
 		for (ExportGroup eg : exportGroups) {
-			Exporter exporter = eg.getExporter();
-			GroupProxy group = eg.getGroup();
-			
-			if (group != null) {
-				exporter.export(group, staticConfig, this);
-			} else {
-				for (GroupProxy grp : staticConfig.getPropertyGroups()) {
-					exporter.export(grp, staticConfig, this);
-				}
-			}
+			eg.getExporter().export(eg.getGroup(), staticConfig, this);
 		}
 		
 		//Print samples (if requested) to System.out


### PR DESCRIPTION
* Removed dead code that was never used related to bulk exports
* Deprecated method has a default no-op implementation so subclasses don't need to implement it
* Improve javadocs

### All Submissions:

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
