### PR TITLE
Deprecate KeyValuePairLoader.setKeyValuePairs(String... keyValuePairs)

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/KeyValuePairLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/KeyValuePairLoader.java
@@ -68,13 +68,13 @@ public class KeyValuePairLoader extends BaseLoader implements ReadLoader {
 	 * 
 	 * KVPs are split by KVP.splitKVP using '=' as the delimiter, as defined in
 	 * AndHow.KVP_DELIMITER.
-	 * 
-	 * @param keyValuePairs 
+	 *
+	 * @deprecated Use {@code KeyValuePairLoader.setKeyValuePairs(List<String>)} instead.
+	 * @param keyValuePairs
 	 */
+	@Deprecated
 	public void setKeyValuePairs(String... keyValuePairs) {
-		if (keyValuePairs != null && keyValuePairs.length > 0) {
-			this.keyValuePairs.addAll(Arrays.asList(keyValuePairs));
-		}
+		this.setKeyValuePairs(keyValuePairs != null ? Arrays.asList(keyValuePairs) : null);
 	}
 	
 	@Override

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/KeyValuePairLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/KeyValuePairLoaderTest.java
@@ -79,6 +79,20 @@ public class KeyValuePairLoaderTest extends BaseForLoaderTests {
 		assertEquals(Boolean.FALSE, result.getExplicitValue(SimpleParams.FLAG_TRUE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
+
+		// set null has no effect
+		cll.setKeyValuePairs((String[]) null);
+
+		result = cll.load(appDef, appValuesBuilder);
+
+		assertEquals(0, result.getProblems().size());
+		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
+		assertEquals("test", result.getExplicitValue(SimpleParams.STR_BOB));
+		assertEquals("not_null", result.getExplicitValue(SimpleParams.STR_NULL));
+		assertEquals("something_XXX", result.getExplicitValue(SimpleParams.STR_ENDS_WITH_XXX));
+		assertEquals(Boolean.FALSE, result.getExplicitValue(SimpleParams.FLAG_TRUE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
 	}
 	
 


### PR DESCRIPTION
Fixes #552

* Deprecate KeyValuePairLoader.setKeyValuePairs(String... keyValuePairs)

### All Submissions:

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
