### PR TITLE
Deprecate FixedValueLoader#setPropertyValues(PropertyValue... values)

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/FixedValueLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/FixedValueLoader.java
@@ -45,17 +45,12 @@ public class FixedValueLoader extends BaseLoader implements ReadLoader {
 	}
 
 	/**
-	 * @deprecated This method duplicates functionality and will
-	 * be removed.  The logic of this method is slightly wrong as
-	 * well (compared to the List version):  As this method is currently
-	 * implemente, an empty array will NOT erase all values.  The
-	 * Other List based methods would erase all values in that case.
+	 * @deprecated Use {@code FixedValueLoader.setPropertyValues(List<PropertyValue>)} instead.
 	 * @param values
 	 */
+	@Deprecated
 	public void setPropertyValues(PropertyValue... values) {
-		if (values != null && values.length > 0) {
-			this.values.addAll(Arrays.asList(values));
-		}
+		this.setPropertyValues(values != null ? Arrays.asList(values) : null);
 	}
 
 	/**

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/FixedValueLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/FixedValueLoaderTest.java
@@ -158,4 +158,54 @@ public class FixedValueLoaderTest extends BaseForLoaderTests {
 		//The initial assignment should have still worked
 		assertEquals("test", result.getExplicitValue(SimpleParams.STR_BOB));
 	}
+
+	@Test
+	public void happyPathViaPropertyValuesAsArrayTest() {
+
+		List<PropertyValue> props = new ArrayList();
+		props.add(new PropertyValue(STR_BOB, "test"));
+		props.add(new PropertyValue(STR_NULL, "not_null"));
+		props.add(new PropertyValue(STR_ENDS_WITH_XXX, "XXX"));
+
+		//spaces on non-string values should be trimmed and not matter
+		props.add(new PropertyValue(LNG_TIME, "60"));		//as string
+		props.add(new PropertyValue(INT_NUMBER, 30));	//As exact value type (int)
+		props.add(new PropertyValue(DBL_NUMBER, "123.456D"));	//as string
+		props.add(new PropertyValue(FLAG_TRUE, " false "));
+		props.add(new PropertyValue(FLAG_FALSE, " true "));
+		props.add(new PropertyValue(FLAG_NULL, " true "));
+
+
+		FixedValueLoader loader = new FixedValueLoader();
+		loader.setPropertyValues(props.toArray(new PropertyValue[0]));
+
+		LoaderValues result = loader.load(appDef, appValuesBuilder);
+
+		assertEquals(0, result.getProblems().size());
+		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
+		assertEquals("test", result.getExplicitValue(SimpleParams.STR_BOB));
+		assertEquals("not_null", result.getExplicitValue(SimpleParams.STR_NULL));
+		assertEquals("XXX", result.getExplicitValue(STR_ENDS_WITH_XXX));
+		assertEquals(60L, result.getExplicitValue(LNG_TIME));
+		assertEquals(30, result.getExplicitValue(INT_NUMBER));
+		assertEquals(Boolean.FALSE, result.getExplicitValue(FLAG_TRUE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(FLAG_FALSE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(FLAG_NULL));
+
+		// set null has no effect
+		loader.setPropertyValues((PropertyValue[]) null);
+
+		result = loader.load(appDef, appValuesBuilder);
+
+		assertEquals(0, result.getProblems().size());
+		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
+		assertEquals("test", result.getExplicitValue(SimpleParams.STR_BOB));
+		assertEquals("not_null", result.getExplicitValue(SimpleParams.STR_NULL));
+		assertEquals("XXX", result.getExplicitValue(STR_ENDS_WITH_XXX));
+		assertEquals(60L, result.getExplicitValue(LNG_TIME));
+		assertEquals(30, result.getExplicitValue(INT_NUMBER));
+		assertEquals(Boolean.FALSE, result.getExplicitValue(FLAG_TRUE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(FLAG_FALSE));
+		assertEquals(Boolean.TRUE, result.getExplicitValue(FLAG_NULL));
+	}
 }


### PR DESCRIPTION
Fixes #553 

* Deprecate FixedValueLoader#setPropertyValues(PropertyValue... values)
* Change javadoc
* Add unit test.

### All Submissions:

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
