### PR TITLE
Issue587 shorted StrProp builder

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/Options.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/Options.java
@@ -25,7 +25,7 @@ public interface Options {
 			.desc("Forces configuration samples to be sent to the console for each loader that supports it.")
 			.helpText("On cmdline, this works as a flag and is assumed 'true' just by being present. In other config sources it can be set to 'true'.")
 			.build();
-	StrProp SAMPLES_DIRECTORY = StrProp.builder().defaultValue("java.io.tmpdir/andhow-samples/").mustBeNonNull().mustEndWith("/")
+	StrProp SAMPLES_DIRECTORY = StrProp.builder().defaultValue("java.io.tmpdir/andhow-samples/").mustBeNonNull().endsWith("/")
 			.desc("Path to a directory to be used to write sample configuration to. "
 					+ "The special 'java.io.tmpdir' string is recognized as the current Java temp directory.")
 			.helpText("All paths should be specified w/ forward slashes, even on windows systems.")

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/StrProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/StrProp.java
@@ -7,13 +7,13 @@ import org.yarnandtail.andhow.valuetype.StrType;
 
 /**
  * A Property that refers to a String value.
- * 
+ *
  * All the basic Java types use a three letter abv. to keep declaration lines
  * short, in the form of: [Type]Prop
- * 
+ *
  * By default, this uses the QuotedSpacePreservingTrimmer, which will keep
  * whitespace inside double quotes.
- * 
+ *
  * @author eeverman
  */
 public class StrProp extends PropertyBase<String> {
@@ -43,32 +43,80 @@ public class StrProp extends PropertyBase<String> {
 					_valueType, _trimmer, _helpText);
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.matches()}
+		 */
+		@Deprecated
 		public StrBuilder mustMatchRegex(String regex) {
+			return this.matches(regex);
+		}
+
+		public StrBuilder matches(String regex) {
 			this.validation(new StringValidator.Regex(regex));
 			return this;
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.startsWith()}
+		 */
+		@Deprecated
 		public StrBuilder mustStartWith(String prefix) {
+			return this.startsWith(prefix);
+		}
+
+		public StrBuilder startsWith(String prefix) {
 			this.validation(new StringValidator.StartsWith(prefix, false));
 			return this;
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.startsWithIgnoringCase()}
+		 */
+		@Deprecated
 		public StrBuilder mustStartWithIgnoreCase(String prefix) {
+			return this.startsWithIgnoringCase(prefix);
+		}
+
+		public StrBuilder startsWithIgnoringCase(String prefix) {
 			this.validation(new StringValidator.StartsWith(prefix, true));
 			return this;
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.endsWith()}
+		 */
+		@Deprecated
 		public StrBuilder mustEndWith(String sufix) {
-			this.validation(new StringValidator.EndsWith(sufix, false));
+			return this.endsWith(sufix);
+		}
+
+		public StrBuilder endsWith(String suffix) {
+			this.validation(new StringValidator.EndsWith(suffix, false));
 			return this;
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.endsWithIgnoringCase()}
+		 */
+		@Deprecated
 		public StrBuilder mustEndWithIgnoreCase(String sufix) {
-			this.validation(new StringValidator.EndsWith(sufix, true));
+			return this.endsWithIgnoringCase(sufix);
+		}
+
+		public StrBuilder endsWithIgnoringCase(String suffix) {
+			this.validation(new StringValidator.EndsWith(suffix, true));
 			return this;
 		}
 
+		/**
+		 * @deprecated Use {@code StrBuilder.oneOf()}
+		 */
+		@Deprecated
 		public StrBuilder mustEqual(String... values) {
+			return this.oneOf(values);
+		}
+
+		public StrBuilder oneOf(String... values) {
 			this.validation(new StringValidator.Equals(values));
 			return this;
 		}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * When the AndHow.instance(config) method is removed, this test will need to be
  * updated to call the private AndHow.initialize(config).
- * 
+ *
  * @author ericeverman
  */
 public class AndHowTest extends AndHowTestBase {
@@ -39,28 +39,28 @@ public class AndHowTest extends AndHowTestBase {
 	ArrayList<Class<?>> configPtGroups = new ArrayList();
 	Map<Property<?>, Object> startVals = new HashMap();
 	String[] cmdLineArgsWFullClassName = new String[0];
-	
+
 	public static interface RequiredParams {
 		StrProp STR_BOB_R = StrProp.builder().defaultValue("Bob").mustBeNonNull().build();
-		StrProp STR_NULL_R = StrProp.builder().mustBeNonNull().mustStartWith("XYZ").build();
+		StrProp STR_NULL_R = StrProp.builder().mustBeNonNull().startsWith("XYZ").build();
 		FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).mustBeNonNull().build();
 		FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).mustBeNonNull().build();
 		FlagProp FLAG_NULL = FlagProp.builder().mustBeNonNull().build();
 	}
-	
+
 	@BeforeEach
 	public void setup() throws Exception {
-		
+
 		configPtGroups.clear();
 		configPtGroups.add(SimpleParams.class);
-		
+
 		startVals.clear();
 		startVals.put(SimpleParams.STR_BOB, "test");
 		startVals.put(SimpleParams.STR_NULL, "not_null");
 		startVals.put(SimpleParams.FLAG_TRUE, Boolean.FALSE);
 		startVals.put(SimpleParams.FLAG_FALSE, Boolean.TRUE);
 		startVals.put(SimpleParams.FLAG_NULL, Boolean.TRUE);
-		
+
 		cmdLineArgsWFullClassName = new String[] {
 			paramFullPath + "STR_BOB" + KeyValuePairLoader.KVP_DELIMITER + "test",
 			paramFullPath + "STR_NULL" + KeyValuePairLoader.KVP_DELIMITER + "not_null",
@@ -68,7 +68,7 @@ public class AndHowTest extends AndHowTestBase {
 			paramFullPath + "FLAG_FALSE" + KeyValuePairLoader.KVP_DELIMITER + "true",
 			paramFullPath + "FLAG_NULL" + KeyValuePairLoader.KVP_DELIMITER + "true"
 		};
-		
+
 	}
 
 	@Test
@@ -243,16 +243,16 @@ public class AndHowTest extends AndHowTestBase {
 		assertSame(config1, initLoopEx.getOriginalInit().getConfig());
 		assertSame(config2, initLoopEx.getSecondInit().getConfig());
 	}
-	
+
 	@Test
 	public void testCmdLineLoaderUsingClassBaseName() {
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroups(configPtGroups)
 				.setCmdLineArgs(cmdLineArgsWFullClassName);
-		
+
 		AndHow.instance(config);
-		
+
 		assertTrue(AndHow.getInitializationTrace().length > 0);
 		//STR_BOB (Set to 'test')
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
@@ -285,17 +285,17 @@ public class AndHowTest extends AndHowTestBase {
 		assertNull(SimpleParams.LDT_NULL.getValue());
 
 	}
-	
+
 	/**
 	 * This is really testing how the NonProductionConfig works - how can this be
 	 * targeted to the init config?
 	 */
 	@Test
 	public void testBlowingUpWithDuplicateLoaders() {
-		
+
 		KeyValuePairLoader kvpl = new KeyValuePairLoader();
 		kvpl.setKeyValuePairs(cmdLineArgsWFullClassName);
-		
+
 		try {
 
 			AndHowConfiguration config = AndHowTestConfig.instance()
@@ -304,54 +304,54 @@ public class AndHowTest extends AndHowTestBase {
 
 			AndHow.setConfig(config);
 			AndHow.instance();
-			
+
 			fail();	//The line above should throw an error
 		} catch (AppFatalException ce) {
 			assertEquals(1, ce.getProblems().filter(ConstructionProblem.class).size());
 			assertTrue(ce.getProblems().filter(ConstructionProblem.class).get(0) instanceof ConstructionProblem.DuplicateLoader);
-			
+
 			ConstructionProblem.DuplicateLoader dl = (ConstructionProblem.DuplicateLoader)ce.getProblems().filter(ConstructionProblem.class).get(0);
 			assertEquals(kvpl, dl.getLoader());
 			assertTrue(ce.getSampleDirectory().length() > 0);
-			
+
 			File sampleDir = new File(ce.getSampleDirectory());
 			assertTrue(sampleDir.exists());
 			assertTrue(sampleDir.listFiles().length > 0);
 		}
 	}
-	
+
 	@Test
 	public void testCmdLineLoaderMissingRequiredParamShouldThrowAConfigException() {
-		
+
 		try {
 				AndHowConfiguration config = AndHowTestConfig.instance()
 					.addOverrideGroups(configPtGroups)
 					.addOverrideGroup(RequiredParams.class)
 					.setCmdLineArgs(cmdLineArgsWFullClassName);
-				
+
 				AndHow.instance(config);
-			
+
 			fail();	//The line above should throw an error
 		} catch (AppFatalException ce) {
 			assertEquals(1, ce.getProblems().filter(RequirementProblem.class).size());
 			assertEquals(RequiredParams.STR_NULL_R, ce.getProblems().filter(RequirementProblem.class).get(0).getPropertyCoord().getProperty());
 		}
 	}
-	
+
 	@Test
 	public void testInvalidValuesShouldCauseValidationException() {
-		
+
 		String baseName = AndHowTest.class.getCanonicalName();
 		baseName += "." + RequiredParams.class.getSimpleName() + ".";
-		
+
 		try {
 				AndHowConfiguration config = AndHowTestConfig.instance()
 					.addOverrideGroup(RequiredParams.class)
 					.addCmdLineArg(baseName + "STR_NULL_R", "zzz")
 					.addCmdLineArg(baseName + "FLAG_NULL", "present");
-				
+
 				AndHow.instance(config);
-			
+
 			fail();	//The line above should throw an error
 		} catch (AppFatalException ce) {
 			assertEquals(1, ce.getProblems().filter(ValueProblem.class).size());
@@ -375,5 +375,5 @@ public class AndHowTest extends AndHowTestBase {
 		assertTrue(startTime <= init.getTimeStamp());
 		assertTrue(endTime >= init.getTimeStamp());
 	}
-	
+
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -5,38 +5,38 @@ import org.yarnandtail.andhow.property.*;
 
 /**
  * Test set of params w/ one of each type.
- * 
+ *
  * Naming is [type]_[default value]
- * 
+ *
  * @author eeverman
  */
 public interface SimpleParams {
-	
+
 	//Strings
 	StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 	StrProp STR_NULL = StrProp.builder().aliasInAndOut("String_Null").build();
-	StrProp STR_END_XXX = StrProp.builder().mustEndWith("XXX").build();
-	
+	StrProp STR_END_XXX = StrProp.builder().endsWith("XXX").build();
+
 	//Flags
 	FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).build();
 	FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).build();
 	FlagProp FLAG_NULL = FlagProp.builder().build();
-	
+
 	//Integers
 	IntProp INT_TEN = IntProp.builder().defaultValue(10).build();
 	IntProp INT_NULL = IntProp.builder().build();
 	IntProp INT_BIG_TEN = IntProp.builder().mustBeGreaterThan(10).build();
-	
+
 	//Long
 	LngProp LNG_TEN = LngProp.builder().defaultValue(10L).build();
 	LngProp LNG_NULL = LngProp.builder().build();
 	LngProp LNG_LESS_TEN = LngProp.builder().mustBeLessThan(10L).build();
-	
+
 	//Double
 	DblProp DBL_TEN = DblProp.builder().defaultValue(10d).build();
 	DblProp DBL_NULL = DblProp.builder().build();
 	DblProp DBL_LESS_ZERO = DblProp.builder().mustBeLessThan(0).build();
-	
+
 	//LocalDateTime
 	LocalDateTimeProp LDT_2007_10_01 = LocalDateTimeProp.builder().defaultValue(LocalDateTime.parse("2007-10-01T00:00")).build();
 	LocalDateTimeProp LDT_NULL = LocalDateTimeProp.builder().build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
@@ -27,7 +27,7 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 	private static final String GROUP_PATH = "org.yarnandtail.andhow.StdConfigSimulatedAppTest.SampleRestClientGroup";
 	private static final String CLASSPATH_BEGINNING = "/org/yarnandtail/andhow/StdConfigSimulatedAppTest.";
 
-	
+
 	@Test
 	public void testAllValuesAreSetViaCmdLineArgAndPropFile() {
 
@@ -35,15 +35,15 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		String[] cmdLineArgs = new String[] {
 			GROUP_PATH + ".classpath_prop_file" + KVP_DELIMITER + CLASSPATH_BEGINNING + "all.props.speced.properties"
 		};
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SampleRestClientGroup.class)
 				.setCmdLineArgs(cmdLineArgs)
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
-		
+
 		AndHow.setConfig(config);
-		
+
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
 		assertAllPointsSpecedValues("testAllValuesAreSetViaCmdLineArgAndPropFile");
@@ -176,14 +176,14 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		assertFalse(SampleRestClientGroup.REQUEST_META_DATA.getValue(), failDesc);
 		assertTrue(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue(), failDesc);
 	}
-	
+
 	@Test
 	public void testMinimumPropsAreSetViaCmdLineArgAndPropFile() {
 
 		String[] cmdLineArgs = new String[] {
 				GROUP_PATH + ".CLASSPATH_PROP_FILE" + KVP_DELIMITER + CLASSPATH_BEGINNING + "minimum.props.speced.properties"
-		};		
-				
+		};
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SampleRestClientGroup.class)
 				.setCmdLineArgs(cmdLineArgs)
@@ -191,7 +191,7 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 				.classpathPropertiesRequired();
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.minimum.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
 		assertEquals("aquarius.usgs.gov", SampleRestClientGroup.REST_HOST.getValue());
@@ -203,10 +203,10 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		assertFalse(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue());	//a default
 
 	}
-	
+
 	@Test
 	public void testInvalidValuesViaCmdLineArgAndPropFile() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		jndi.activate();
 
@@ -249,9 +249,9 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 	interface SampleRestClientGroup {
 		StrProp CLASSPATH_PROP_FILE = StrProp.builder().desc("Classpath location of a properties file w/ props").build();
 		StrProp APP_NAME = StrProp.builder().aliasIn("app.name").aliasIn("app_name").build();
-		StrProp REST_HOST = StrProp.builder().mustMatchRegex(".*\\.usgs\\.gov") .mustBeNonNull().build();
+		StrProp REST_HOST = StrProp.builder().matches(".*\\.usgs\\.gov") .mustBeNonNull().build();
 		IntProp REST_PORT = IntProp.builder().mustBeNonNull().mustBeGreaterThanOrEqualTo(80).mustBeLessThan(10000).build();
-		StrProp REST_SERVICE_NAME = StrProp.builder().defaultValue("query/").mustEndWith("/").build();
+		StrProp REST_SERVICE_NAME = StrProp.builder().defaultValue("query/").endsWith("/").build();
 		StrProp AUTH_KEY = StrProp.builder().mustBeNonNull().build();
 		IntProp RETRY_COUNT = IntProp.builder().defaultValue(2).build();
 		FlagProp REQUEST_META_DATA = FlagProp.builder().defaultValue(true).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationImmutableTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationImmutableTest.java
@@ -18,92 +18,92 @@ import org.yarnandtail.andhow.util.NameUtil;
  * @author eeverman
  */
 public class StaticPropertyConfigurationImmutableTest {
-	
+
 	String paramFullPath = SimpleParams.class.getCanonicalName() + ".";
-	
+
 	public interface SimpleParams {
 		StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 		FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).build();
 	}
-	
+
 	//Two PropGroups w/ a duplicate (shared) property
 	public interface SampleGroup { StrProp STR_1 = StrProp.builder().build(); }
 	public interface SampleGroupDup { StrProp STR_1_DUP = SampleGroup.STR_1; }
-	
+
 	public interface RandomUnregisteredGroup { StrProp STR_RND = StrProp.builder().build(); }
-	
+
 	/**
 	 * Used for testing bad default value (don't match the validator) and bad validator config (invalid regex).
 	 */
 	public static interface BadDefaultAndValidationGroup {
-		StrProp NAME_WITH_BAD_REGEX = StrProp.builder().mustMatchRegex("The[broekn.*").defaultValue("The Big Chill").build();
-		StrProp COLOR_WITH_BAD_DEFAULT = StrProp.builder().mustMatchRegex("[A-F,0-9]*").defaultValue("Red").build();
-		StrProp COLOR_WITH_OK_DEFAULT = StrProp.builder().mustMatchRegex("[A-F,0-9]*").defaultValue("FFF000").build();
+		StrProp NAME_WITH_BAD_REGEX = StrProp.builder().matches("The[broekn.*").defaultValue("The Big Chill").build();
+		StrProp COLOR_WITH_BAD_DEFAULT = StrProp.builder().matches("[A-F,0-9]*").defaultValue("Red").build();
+		StrProp COLOR_WITH_OK_DEFAULT = StrProp.builder().matches("[A-F,0-9]*").defaultValue("FFF000").build();
 
 	}
 
-	
+
 	@Test
 	public void testHappyPath() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
-		
+
 		GroupProxy proxy = AndHowUtil.buildGroupProxy(SimpleParams.class);
-		
+
 		StaticPropertyConfigurationMutable cdm = new StaticPropertyConfigurationMutable(bns);
 		cdm.addProperty(proxy, SimpleParams.STR_BOB);
 		cdm.addProperty(proxy, SimpleParams.FLAG_FALSE);
-		
-		
+
+
 		StaticPropertyConfigurationInternal appDef = cdm.toImmutable();
-		
+
 		//Canonical Names for Property
 		assertEquals(paramFullPath + "STR_BOB", appDef.getCanonicalName(SimpleParams.STR_BOB));
 		assertEquals(paramFullPath + "FLAG_FALSE", appDef.getCanonicalName(SimpleParams.FLAG_FALSE));
-		
+
 		//Get properties for Canonical name
 		assertEquals(SimpleParams.STR_BOB, appDef.getProperty(paramFullPath + "STR_BOB"));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getProperty(paramFullPath + "FLAG_FALSE"));
 
-		
+
 		//Groups
 		assertEquals(1, appDef.getPropertyGroups().size());
 		assertEquals(proxy, appDef.getPropertyGroups().get(0));
-		
+
 		//prop list
 		assertEquals(2, appDef.getProperties().size());
 		assertEquals(SimpleParams.STR_BOB, appDef.getProperties().get(0));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getProperties().get(1));
-		
+
 		//Properties for Group
 		assertEquals(2, appDef.getPropertiesForGroup(proxy).size());
 		assertEquals(SimpleParams.STR_BOB, appDef.getPropertiesForGroup(proxy).get(0));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getPropertiesForGroup(proxy).get(1));
 	}
-	
+
 	@Test
 	public void testDuplicatePropertiesInSeparateGroupWithDistinctNames() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
 		ProblemList<ConstructionProblem> problems = new ProblemList();
 		StaticPropertyConfigurationMutable cdm = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy sampleGroupProxy = AndHowUtil.buildGroupProxy(SampleGroup.class);
 		GroupProxy sampleGroupDupProxy = AndHowUtil.buildGroupProxy(SampleGroupDup.class);
-		
+
 		problems.add(cdm.addProperty(sampleGroupProxy, SampleGroup.STR_1));
 
 		problems.add(cdm.addProperty(sampleGroupDupProxy, SampleGroupDup.STR_1_DUP));
-		
+
 		StaticPropertyConfigurationInternal appDef = cdm.toImmutable();
-		
+
 		assertEquals(1, appDef.getProperties().size());
 		assertEquals(SampleGroup.STR_1, appDef.getProperties().get(0));
 		assertEquals(1, problems.size());
 		assertTrue(problems.get(0) instanceof ConstructionProblem.DuplicateProperty);
-		
+
 		ConstructionProblem.DuplicateProperty dpcp = (ConstructionProblem.DuplicateProperty)problems.get(0);
-		
+
 		assertEquals(SampleGroup.STR_1, dpcp.getRefPropertyCoord().getProperty());
 		assertEquals(SampleGroup.class, dpcp.getRefPropertyCoord().getGroup());
 		assertEquals(NameUtil.getAndHowName(SampleGroup.class, SampleGroup.STR_1), dpcp.getRefPropertyCoord().getPropName());
@@ -112,35 +112,35 @@ public class StaticPropertyConfigurationImmutableTest {
 		assertEquals(NameUtil.getAndHowName(SampleGroupDup.class, SampleGroupDup.STR_1_DUP), dpcp.getBadPropertyCoord().getPropName());
 	}
 
-	
+
 	@Test
 	public void testNonValidDefaultValueAndInvalidRegexValidationSpec() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
 		ProblemList<ConstructionProblem> problems = new ProblemList();
 		StaticPropertyConfigurationMutable cdm = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy proxy = AndHowUtil.buildGroupProxy(BadDefaultAndValidationGroup.class);
-		
+
 		problems.add(cdm.addProperty(proxy, BadDefaultAndValidationGroup.NAME_WITH_BAD_REGEX));
 
 		problems.add(cdm.addProperty(proxy, BadDefaultAndValidationGroup.COLOR_WITH_BAD_DEFAULT));
-		
+
 		problems.add(cdm.addProperty(proxy, BadDefaultAndValidationGroup.COLOR_WITH_OK_DEFAULT));
-		
+
 		StaticPropertyConfigurationInternal appDef = cdm.toImmutable();
-		
+
 		assertEquals(1, appDef.getProperties().size());
 		assertEquals(BadDefaultAndValidationGroup.COLOR_WITH_OK_DEFAULT, appDef.getProperties().get(0));
 		assertEquals(2, problems.size());
 		assertTrue(problems.get(0) instanceof ConstructionProblem.InvalidValidationConfiguration);
 		assertTrue(problems.get(1) instanceof ConstructionProblem.InvalidDefaultValue);
-		
+
 		ConstructionProblem.InvalidValidationConfiguration invalidConfig = (ConstructionProblem.InvalidValidationConfiguration)problems.get(0);
 		ConstructionProblem.InvalidDefaultValue invalidDefault = (ConstructionProblem.InvalidDefaultValue)problems.get(1);
 
-		
-		
+
+
 		assertEquals(BadDefaultAndValidationGroup.NAME_WITH_BAD_REGEX, invalidConfig.getBadPropertyCoord().getProperty());
 		assertEquals(BadDefaultAndValidationGroup.class, invalidConfig.getBadPropertyCoord().getGroup());
 		assertEquals(false, invalidConfig.getValidator().isSpecificationValid());
@@ -149,6 +149,6 @@ public class StaticPropertyConfigurationImmutableTest {
 
 
 	}
-	
+
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationMutableTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/internal/StaticPropertyConfigurationMutableTest.java
@@ -19,75 +19,75 @@ import org.yarnandtail.andhow.util.NameUtil;
  * @author eeverman
  */
 public class StaticPropertyConfigurationMutableTest {
-	
+
 	String paramFullPath = SimpleParams.class.getCanonicalName() + ".";
-	
+
 	public interface SimpleParams {
 		StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 		FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).build();
 	}
-	
+
 	public interface SampleGroup { StrProp STR_1 = StrProp.builder().build(); }
 	public interface SampleGroupDup { StrProp STR_1_DUP = SampleGroup.STR_1; }
-	
+
 	public interface RandomUnregisteredGroup { StrProp STR_RND = StrProp.builder().build(); }
-	
+
 	@Test
 	public void testHappyPath() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
-		
+
 		StaticPropertyConfigurationMutable appDef = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy proxy = AndHowUtil.buildGroupProxy(SimpleParams.class);
-		
+
 		appDef.addProperty(proxy, SimpleParams.STR_BOB);
 		appDef.addProperty(proxy, SimpleParams.FLAG_FALSE);
 
 		//Canonical Names for Property
 		assertEquals(paramFullPath + "STR_BOB", appDef.getCanonicalName(SimpleParams.STR_BOB));
 		assertEquals(paramFullPath + "FLAG_FALSE", appDef.getCanonicalName(SimpleParams.FLAG_FALSE));
-		
+
 		//Get properties for Canonical name
 		assertEquals(SimpleParams.STR_BOB, appDef.getProperty(paramFullPath + "STR_BOB"));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getProperty(paramFullPath + "FLAG_FALSE"));
 
-		
+
 		//Groups
 		assertEquals(1, appDef.getPropertyGroups().size());
 		assertEquals(proxy, appDef.getPropertyGroups().get(0));
-		
+
 		//prop list
 		assertEquals(2, appDef.getProperties().size());
 		assertEquals(SimpleParams.STR_BOB, appDef.getProperties().get(0));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getProperties().get(1));
-		
+
 		//Properties for Group
 		assertEquals(2, appDef.getPropertiesForGroup(proxy).size());
 		assertEquals(SimpleParams.STR_BOB, appDef.getPropertiesForGroup(proxy).get(0));
 		assertEquals(SimpleParams.FLAG_FALSE, appDef.getPropertiesForGroup(proxy).get(1));
 	}
-	
+
 	@Test
 	public void testDuplicatePropertiesInSeparateGroupWithDistinctNames() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
 		ProblemList<ConstructionProblem> problems = new ProblemList();
 		StaticPropertyConfigurationMutable appDef = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy sampleGroupProxy = AndHowUtil.buildGroupProxy(SampleGroup.class);
 		GroupProxy sampleGroupDupProxy = AndHowUtil.buildGroupProxy(SampleGroupDup.class);
-		
+
 		problems.add(appDef.addProperty(sampleGroupProxy, SampleGroup.STR_1));
 		problems.add(appDef.addProperty(sampleGroupDupProxy, SampleGroupDup.STR_1_DUP));
-		
+
 		assertEquals(1, appDef.getProperties().size());
 		assertEquals(SampleGroup.STR_1, appDef.getProperties().get(0));
 		assertEquals(1, problems.size());
 		assertTrue(problems.get(0) instanceof ConstructionProblem.DuplicateProperty);
-		
+
 		ConstructionProblem.DuplicateProperty dpcp = (ConstructionProblem.DuplicateProperty)problems.get(0);
-		
+
 		assertEquals(SampleGroup.STR_1, dpcp.getRefPropertyCoord().getProperty());
 		assertEquals(SampleGroup.class, dpcp.getRefPropertyCoord().getGroup());
 		assertEquals(NameUtil.getAndHowName(SampleGroup.class, SampleGroup.STR_1), dpcp.getRefPropertyCoord().getPropName());
@@ -96,31 +96,31 @@ public class StaticPropertyConfigurationMutableTest {
 		assertEquals(NameUtil.getAndHowName(SampleGroupDup.class, SampleGroupDup.STR_1_DUP), dpcp.getBadPropertyCoord().getPropName());
 	}
 
-	
+
 	@Test
 	public void testNonValidDefaultValueAndInvalidRegexValidationSpec() throws Exception {
-		
+
 		NamingStrategy bns = new CaseInsensitiveNaming();
 		ProblemList<ConstructionProblem> problems = new ProblemList();
 		StaticPropertyConfigurationMutable appDef = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy proxy = AndHowUtil.buildGroupProxy(BadDefaultAndValidationGroup.class);
-		
+
 		problems.add(appDef.addProperty(proxy, BadDefaultAndValidationGroup.NAME_WITH_BAD_REGEX));
 		problems.add(appDef.addProperty(proxy, BadDefaultAndValidationGroup.COLOR_WITH_BAD_DEFAULT));
 		problems.add(appDef.addProperty(proxy, BadDefaultAndValidationGroup.COLOR_WITH_OK_DEFAULT));
-		
+
 		assertEquals(1, appDef.getProperties().size());
 		assertEquals(BadDefaultAndValidationGroup.COLOR_WITH_OK_DEFAULT, appDef.getProperties().get(0));
 		assertEquals(2, problems.size());
 		assertTrue(problems.get(0) instanceof ConstructionProblem.InvalidValidationConfiguration);
 		assertTrue(problems.get(1) instanceof ConstructionProblem.InvalidDefaultValue);
-		
+
 		ConstructionProblem.InvalidValidationConfiguration invalidConfig = (ConstructionProblem.InvalidValidationConfiguration)problems.get(0);
 		ConstructionProblem.InvalidDefaultValue invalidDefault = (ConstructionProblem.InvalidDefaultValue)problems.get(1);
 
-		
-		
+
+
 		assertEquals(BadDefaultAndValidationGroup.NAME_WITH_BAD_REGEX, invalidConfig.getBadPropertyCoord().getProperty());
 		assertEquals(BadDefaultAndValidationGroup.class, invalidConfig.getBadPropertyCoord().getGroup());
 		assertEquals(false, invalidConfig.getValidator().isSpecificationValid());
@@ -129,13 +129,13 @@ public class StaticPropertyConfigurationMutableTest {
 
 
 	}
-	
+
 	/**
 	 * Used for testing bad default value (don't match the validator) and bad validator config (invalid regex).
 	 */
 	public static interface BadDefaultAndValidationGroup {
-		StrProp NAME_WITH_BAD_REGEX = StrProp.builder().mustMatchRegex("The[broekn.*").defaultValue("The Big Chill").build();
-		StrProp COLOR_WITH_BAD_DEFAULT = StrProp.builder().mustMatchRegex("[A-F,0-9]*").defaultValue("Red").build();
-		StrProp COLOR_WITH_OK_DEFAULT = StrProp.builder().mustMatchRegex("[A-F,0-9]*").defaultValue("FFF000").build();
+		StrProp NAME_WITH_BAD_REGEX = StrProp.builder().matches("The[broekn.*").defaultValue("The Big Chill").build();
+		StrProp COLOR_WITH_BAD_DEFAULT = StrProp.builder().matches("[A-F,0-9]*").defaultValue("Red").build();
+		StrProp COLOR_WITH_OK_DEFAULT = StrProp.builder().matches("[A-F,0-9]*").defaultValue("FFF000").build();
 	}
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/BaseForLoaderTests.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/BaseForLoaderTests.java
@@ -45,7 +45,7 @@ public class BaseForLoaderTests {
 		//Strings
 		StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 		StrProp STR_NULL = StrProp.builder().aliasInAndOut("String_Null").build();
-		StrProp STR_ENDS_WITH_XXX = StrProp.builder().mustEndWith("XXX").build();
+		StrProp STR_ENDS_WITH_XXX = StrProp.builder().endsWith("XXX").build();
 
 		//Some Numbers
 		LngProp LNG_TIME = LngProp.builder().aliasIn("lngIn").build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
@@ -21,31 +21,31 @@ import org.yarnandtail.andhow.util.NameUtil;
  * @author ericeverman
  */
 public class StdJndiLoaderTest extends AndHowTestBase {
-	
+
 	public interface ValidParams {
 		//Strings
-		StrProp STR_XXX = StrProp.builder().mustEndWith("XXX").build();
+		StrProp STR_XXX = StrProp.builder().endsWith("XXX").build();
 		IntProp INT_TEN = IntProp.builder().mustBeGreaterThan(10).build();
 
 	}
-	
+
 	@Test
 	public void testSplit() {
 		StdJndiLoader loader = new StdJndiLoader();
-		
+
 		//This is the default
 		List<String> result = loader.split("java:comp/env/, \"\",");
 		assertEquals(2, result.size());
 		assertEquals("java:comp/env/", result.get(0));
 		assertEquals("", result.get(1));
-		
+
 		//Should leave prefix completely unmodified (not add a trailing slash)
 		result = loader.split(" comp/env , , \"_\",x/y/z");
 		assertEquals(3, result.size());
 		assertEquals("comp/env", result.get(0));
 		assertEquals("_", result.get(1));
 		assertEquals("x/y/z", result.get(2));
-		
+
 		//Should be able to indicate an empty string and whitespace w/ double quotes.
 		result = loader.split(" comp/env , \"\" , \" \"");
 		assertEquals(3, result.size());
@@ -57,39 +57,39 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 
 	@Test
 	public void testHappyPathFromStringsCompEnvAsURIs() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:comp/env/" + 
+
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null");
-		jndi.bind("" + 
+		jndi.bind("" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE)), "false");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), "true");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL)), "TRUE");
-		jndi.bind("" + 
+		jndi.bind("" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), "-999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), "999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), "-999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL)), "999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01)), "2007-11-02T00:00");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL)), "2007-11-02T00:00");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -102,10 +102,10 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsCompEnvAsClasspath() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test");
@@ -120,12 +120,12 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01), "2007-11-02T00:00");
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL), "2007-11-02T00:00");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -140,31 +140,31 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsFromAddedNonStdPaths() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:/test/" + 
+
+		jndi.bind("java:/test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
 		jndi.bind("java:/test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), "false");
-		jndi.bind("java:test/" + 
+		jndi.bind("java:test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), "true");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
 		jndi.bind("java:myapp/root/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), "-999");
 		//This should still work
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), "999");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/,    java:test/  ,   java:myapp/root/")
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -173,17 +173,17 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-999, SimpleParams.INT_TEN.getValue());
 		assertEquals(999, SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsFromAddedAndReplacementNonStdPaths() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:zip/" + 
+
+		jndi.bind("java:zip/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
 		jndi.bind("java:xy/z/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
-		jndi.bind("java:/test/" + 
+		jndi.bind("java:/test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE)), "false");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE), "true");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
@@ -191,15 +191,15 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		//This should NOT work
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), "999");
 		jndi.activate();
-		
-		
+
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addFixedValue(StdJndiLoader.CONFIG.STANDARD_JNDI_ROOTS, "java:zip/,java:xy/z/")
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/  ,  ,java:test/ , java:myapp/root/")
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -208,33 +208,33 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-999, SimpleParams.INT_TEN.getValue());
 		assertNull(SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromObjectsCompEnv() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:comp/env/" + 
+
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null");
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), Boolean.FALSE);
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE), Boolean.TRUE);
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL)), Boolean.TRUE);
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), Integer.valueOf(-999));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), Integer.valueOf(999));
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), Long.valueOf(-999));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL), Long.valueOf(999));
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01)), LocalDateTime.parse("2007-11-02T00:00"));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL), LocalDateTime.parse("2007-11-02T00:00"));
-		
+
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
@@ -250,33 +250,33 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromObjectsRoot() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		//switching values slightly to make sure we are reading the correct ones
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test2");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null2");
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), Boolean.FALSE);
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), Boolean.TRUE);
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), Boolean.TRUE);
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), -9999);
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)),9999);
-		
+
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
-		
+
+
 		assertEquals("test2", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null2", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -285,25 +285,25 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-9999, SimpleParams.INT_TEN.getValue());
 		assertEquals(9999, SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	//
 	//
 	// Non-HappyPath
 	//
-	
+
 	@Test
 	public void testDuplicateValues() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		//switching values slightly to make sure we are reading the correct ones
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test2");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "not_null2");
 
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
@@ -317,20 +317,20 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(1, lps.size());
 		assertTrue(lps.get(0) instanceof LoaderProblem.DuplicatePropertyLoaderProblem);
 	}
-	
+
 
 	@Test
 	public void testObjectConversionErrors() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), Long.valueOf(-9999));
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), Float.valueOf(22));
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), Integer.valueOf(-9999));
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
@@ -348,15 +348,15 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertTrue(lps.get(2) instanceof LoaderProblem.ObjectConversionValueProblem);
 		assertEquals(SimpleParams.LNG_TEN, lps.get(2).getBadValueCoord().getProperty());
 	}
-	
+
 	@Test
 	public void testStringConversionErrors() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), "234.567");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), "Apple");
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), "234.567");
 		jndi.activate();
@@ -378,19 +378,19 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertTrue(vps.get(2) instanceof LoaderProblem.StringConversionLoaderProblem);
 		assertEquals(SimpleParams.LNG_TEN, vps.get(2).getBadValueCoord().getProperty());
 	}
-	
+
 
 	@Test
 	public void testValidationIsEnforcedWhenExactTypeUsed() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(ValidParams.class, ValidParams.INT_TEN), Integer.parseInt("9"));
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(ValidParams.class, ValidParams.STR_XXX)), "YYY");
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(ValidParams.class);
@@ -403,16 +403,16 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 
 		assertEquals(2, vps.size());
 	}
-	
+
 	@Test
 	public void testValidationIsEnforcedWhenConvertsionUsed() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(ValidParams.class, ValidParams.INT_TEN), "9");
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(ValidParams.class);

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBaseTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBaseTest.java
@@ -1,11 +1,7 @@
 package org.yarnandtail.andhow.property;
 
 import org.junit.jupiter.api.Test;
-import org.yarnandtail.andhow.api.AppFatalException;
-import org.yarnandtail.andhow.api.Problem;
-import org.yarnandtail.andhow.api.ProblemList;
 import org.yarnandtail.andhow.api.PropertyType;
-import org.yarnandtail.andhow.internal.ValueProblem;
 import org.yarnandtail.andhow.valuetype.StrType;
 
 import java.util.stream.Collectors;
@@ -141,13 +137,13 @@ public class PropertyBaseTest extends PropertyTestBase {
 	//duplicate and overlapping alias in builder...
 
 	public interface Config {
-		StrProp STR1 = StrProp.builder().mustMatchRegex("[a-z]+")
+		StrProp STR1 = StrProp.builder().matches("[a-z]+")
 				.aliasIn("Str1In1").aliasIn("Str1In2")
 				.aliasOut("Str1Out1").aliasOut("Str1Out2")
 				.aliasInAndOut("Str1InOut1").aliasInAndOut("Str1InOut2")
 				.desc("Str1 Desc").helpText("Str1 Help").build();
 
-		StrProp STR2 = StrProp.builder().mustMatchRegex("[a-z]+").mustEqual("aa", "bb")
+		StrProp STR2 = StrProp.builder().matches("[a-z]+").oneOf("aa", "bb")
 				.aliasIn("Str2In1").aliasIn("Str2In1")	//duplicated
 				.build();
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
@@ -57,20 +57,20 @@ public class StrPropTest extends PropertyTestBase {
 	}
 
 	public interface ValidationGroup {
-		StrProp USER_NAME = StrProp.builder().aliasInAndOut("name").matches("[a-z]+")
+		StrProp USER_NAME = StrProp.builder().aliasInAndOut("name").mustMatchRegex("[a-z]+")
 				.mustBeNonNull().desc("Lowercase Only").build();
 
-		StrProp GMAIL_ANY_CASE = StrProp.builder().endsWithIgnoringCase("@gmail.com")
+		StrProp GMAIL_ANY_CASE = StrProp.builder().mustEndWithIgnoreCase("@gmail.com")
 				.description("Ends w/ @gmail.com").build();
 
-		StrProp GMAIL_LOWER_CASE = StrProp.builder().endsWith("@gmail.com")
+		StrProp GMAIL_LOWER_CASE = StrProp.builder().mustEndWith("@gmail.com")
 				.description("Ends w/ '@gmail.com' and is case sensitive")
 				.helpText("helpMe").build();
 
-		StrProp ABC_ANY_CASE = StrProp.builder().startsWithIgnoringCase("abc")
+		StrProp ABC_ANY_CASE = StrProp.builder().mustStartWithIgnoreCase("abc")
 				.description("Starts with 'abc' of any case").build();
 
-		StrProp ABC_UPPER_CASE = StrProp.builder().startsWith("ABC")
+		StrProp ABC_UPPER_CASE = StrProp.builder().mustStartWith("ABC")
 				.description("Starts with 'ABC' exactly").build();
 	}
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
@@ -9,9 +9,9 @@ import org.yarnandtail.andhow.internal.ValueProblem;
 
 /**
  * Tests StrProp instances as they would be used in an app.
- * 
+ *
  * Focuses on builder functionality, validation and metadata.
- * 
+ *
  * @author ericeverman
  */
 public class StrPropTest extends PropertyTestBase {
@@ -19,58 +19,58 @@ public class StrPropTest extends PropertyTestBase {
 	@Test
 	public void validationGroupGoodValuesTest() {
 		this.buildConfig(this, "_validationGroupGood", ValidationGroup.class);
-		
+
 		assertEquals("abcdefg", ValidationGroup.USER_NAME.getValue());
 		assertEquals("someone@GmAiL.CoM", ValidationGroup.GMAIL_ANY_CASE.getValue());
 		assertEquals("someoneselse@gmail.com", ValidationGroup.GMAIL_LOWER_CASE.getValue());
 		assertEquals("AbCdefg", ValidationGroup.ABC_ANY_CASE.getValue());
 		assertEquals("ABCdefg", ValidationGroup.ABC_UPPER_CASE.getValue());
-		
+
 		assertEquals("Lowercase Only", ValidationGroup.USER_NAME.getDescription());
 		assertEquals("Ends w/ @gmail.com", ValidationGroup.GMAIL_ANY_CASE.getDescription());
 		assertEquals("helpMe", ValidationGroup.GMAIL_LOWER_CASE.getHelpText());
 	}
-	
+
 	@Test
 	public void validationGroupGoodValuesWithQuotesTest() {
 		this.buildConfig(this, "_validationGroupGoodWithQuotes", ValidationGroup.class);
-		
+
 		assertEquals("abcdefg", ValidationGroup.USER_NAME.getValue());
 		assertEquals(" someone@GmAiL.CoM", ValidationGroup.GMAIL_ANY_CASE.getValue());
 		assertEquals(" someoneselse@gmail.com", ValidationGroup.GMAIL_LOWER_CASE.getValue());
 		assertEquals("AbC    ", ValidationGroup.ABC_ANY_CASE.getValue());
 		assertEquals("ABC    ", ValidationGroup.ABC_UPPER_CASE.getValue());
 	}
-	
+
 	@Test
 	public void validationGroupBadValuesTest() {
-		
+
 		try {
 			this.buildConfig(this, "_validationGroupBad", ValidationGroup.class);
 		} catch (AppFatalException e) {
 			ProblemList<Problem> problems = e.getProblems();
 			assertEquals(5, problems.size());
-			
+
 			assertTrue(problems.stream().allMatch(p -> p instanceof ValueProblem));
 		}
 
 	}
-	
+
 	public interface ValidationGroup {
-		StrProp USER_NAME = StrProp.builder().aliasInAndOut("name").mustMatchRegex("[a-z]+")
+		StrProp USER_NAME = StrProp.builder().aliasInAndOut("name").matches("[a-z]+")
 				.mustBeNonNull().desc("Lowercase Only").build();
-		
-		StrProp GMAIL_ANY_CASE = StrProp.builder().mustEndWithIgnoreCase("@gmail.com")
+
+		StrProp GMAIL_ANY_CASE = StrProp.builder().endsWithIgnoringCase("@gmail.com")
 				.description("Ends w/ @gmail.com").build();
-		
-		StrProp GMAIL_LOWER_CASE = StrProp.builder().mustEndWith("@gmail.com")
+
+		StrProp GMAIL_LOWER_CASE = StrProp.builder().endsWith("@gmail.com")
 				.description("Ends w/ '@gmail.com' and is case sensitive")
 				.helpText("helpMe").build();
-		
-		StrProp ABC_ANY_CASE = StrProp.builder().mustStartWithIgnoreCase("abc")
+
+		StrProp ABC_ANY_CASE = StrProp.builder().startsWithIgnoringCase("abc")
 				.description("Starts with 'abc' of any case").build();
-				
-		StrProp ABC_UPPER_CASE = StrProp.builder().mustStartWith("ABC")
+
+		StrProp ABC_UPPER_CASE = StrProp.builder().startsWith("ABC")
 				.description("Starts with 'ABC' exactly").build();
 	}
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
@@ -19,46 +19,46 @@ import org.yarnandtail.andhow.util.TextUtil;
  * @author ericeverman
  */
 public class JndiLoaderSamplePrinterTest {
-	
+
 	StaticPropertyConfigurationMutable config;
 	GroupProxyMutable groupProxy1;
-	
+
 	public static interface Config {
 		IntProp MY_PROP1 = IntProp.builder().build();
 		StrProp MY_PROP2 = StrProp.builder().defaultValue("La la la").desc("mp description")
-				.helpText("Long text on how to use the property").mustStartWith("La").mustEndWith("la")
+				.helpText("Long text on how to use the property").startsWith("La").endsWith("la")
 				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
-	
+
 	@BeforeEach
 	public void setup() {
 		config = new StaticPropertyConfigurationMutable(new CaseInsensitiveNaming());
-		
+
 		groupProxy1 = new GroupProxyMutable(
 				JndiLoaderSamplePrinterTest.Config.class.getCanonicalName(),
 				JndiLoaderSamplePrinterTest.class.getCanonicalName() + "$Config"
 		);
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP1", Config.MY_PROP1));
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP2", Config.MY_PROP2));
-		
+
 		assertNull(config.addProperty(groupProxy1, Config.MY_PROP1));
 		assertNull(config.addProperty(groupProxy1, Config.MY_PROP2));
 
 	}
-	
+
 
 	@Test
 	public void generalTest() throws UnsupportedEncodingException {
-		
+
 		TestPrintStream out = new TestPrintStream();
 		JndiLoaderSamplePrinter printer = new JndiLoaderSamplePrinter();
 		String[] lines;	//The output line array
-		
-		
+
+
 		//Print Sample start
 		out.reset();
 		printer.printSampleStart(config, out);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(6, lines.length);
@@ -68,22 +68,22 @@ public class JndiLoaderSamplePrinterTest {
 		assertEquals("strong.simple.valid.AppConfiguration  -  https://github.com/eeverman/andhow", lines[3]);
 		assertEquals("This sample uses Tomcat syntax. JNDI configuration for other servers will be similar.", lines[4]);
 		assertEquals(TextUtil.repeat("- ", 45) + " -->", lines[5]);
-		
+
 		//Print group header
 		out.reset();
 		printer.printPropertyGroupStart(config, out, groupProxy1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(2, lines.length);
 		assertEquals("<!-- " + TextUtil.repeat("- ", 45), lines[0]);
 		assertEquals("Property Group " + JndiLoaderSamplePrinterTest.Config.class.getCanonicalName() + " -->",
 				lines[1]);
-		
+
 		//Print MY_PROP1
 		out.reset();
 		printer.printProperty(config, out, groupProxy1, Config.MY_PROP1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(3, lines.length);
@@ -94,11 +94,11 @@ public class JndiLoaderSamplePrinterTest {
 				+ "/MY_PROP1\" value=\"[Integer]\" "
 				+ "type=\"java.lang.Integer\" override=\"false\"/>",
 				lines[2]);
-		
+
 		//Print MY_PROP2
 		out.reset();
 		printer.printProperty(config, out, groupProxy1, Config.MY_PROP2);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(9, lines.length);
@@ -115,20 +115,20 @@ public class JndiLoaderSamplePrinterTest {
 				+ "/MY_PROP2\" value=\"La la la\" "
 				+ "type=\"java.lang.String\" override=\"false\"/>",
 				lines[8]);
-		
+
 		//Print group closing (should be empty line)
 		out.reset();
 		printer.printPropertyGroupEnd(config, out, groupProxy1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(1, lines.length);
 		assertEquals("", lines[0]);
-		
+
 		//Print file closing (should be empty line)
 		out.reset();
 		printer.printSampleEnd(config, out);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(1, lines.length);
@@ -183,5 +183,5 @@ public class JndiLoaderSamplePrinterTest {
 	@Test
 	public void testGetSampleFileExtension() {
 	}
-	
+
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
@@ -20,46 +20,46 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author ericeverman
  */
 public class PropFileLoaderSamplePrinterTest {
-	
+
 	StaticPropertyConfigurationMutable config;
 	GroupProxyMutable groupProxy1;
-	
+
 	public static interface Config {
 		IntProp MY_PROP1 = IntProp.builder().build();
 		StrProp MY_PROP2 = StrProp.builder().defaultValue("La la la").desc("mp description")
-				.helpText("Long text on how to use the property").mustStartWith("La").mustEndWith("la")
+				.helpText("Long text on how to use the property").startsWith("La").endsWith("la")
 				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
-	
+
 	@BeforeEach
 	public void setup() {
 		config = new StaticPropertyConfigurationMutable(new CaseInsensitiveNaming());
-		
+
 		groupProxy1 = new GroupProxyMutable(
 				PropFileLoaderSamplePrinterTest.Config.class.getCanonicalName(),
 				PropFileLoaderSamplePrinterTest.class.getCanonicalName() + "$Config"
 		);
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP1", Config.MY_PROP1));
 		groupProxy1.addProperty(new NameAndProperty("MY_PROP2", Config.MY_PROP2));
-		
+
 		assertNull(config.addProperty(groupProxy1, Config.MY_PROP1));
 		assertNull(config.addProperty(groupProxy1, Config.MY_PROP2));
 
 	}
-	
+
 
 	@Test
 	public void generalTest() throws UnsupportedEncodingException {
-		
+
 		TestPrintStream out = new TestPrintStream();
 		PropFileLoaderSamplePrinter printer = new PropFileLoaderSamplePrinter();
 		String[] lines;	//The output line array
-		
-		
+
+
 		//Print Sample start
 		out.reset();
 		printer.printSampleStart(config, out);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(6, lines.length);
@@ -69,11 +69,11 @@ public class PropFileLoaderSamplePrinterTest {
 		assertEquals("# Note: When reading property names, matching is done in a case insensitive way, so 'Bob'", lines[3]);
 		assertEquals("# 	would match 'bOB'.", lines[4]);
 		assertEquals("# " + TextUtil.repeat("##", 45), lines[5]);
-		
+
 		//Print group header
 		out.reset();
 		printer.printPropertyGroupStart(config, out, groupProxy1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(2, lines.length);
@@ -81,11 +81,11 @@ public class PropFileLoaderSamplePrinterTest {
 		assertEquals(
 				"# Property Group " + PropFileLoaderSamplePrinterTest.Config.class.getCanonicalName(),
 				lines[1]);
-		
+
 		//Print MY_PROP1
 		out.reset();
 		printer.printProperty(config, out, groupProxy1, Config.MY_PROP1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(3, lines.length);
@@ -95,11 +95,11 @@ public class PropFileLoaderSamplePrinterTest {
 				PropFileLoaderSamplePrinterTest.Config.class.getCanonicalName() +
 						".MY_PROP1 = [Integer]",
 				lines[2]);
-		
+
 		//Print MY_PROP2
 		out.reset();
 		printer.printProperty(config, out, groupProxy1, Config.MY_PROP2);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(9, lines.length);
@@ -115,20 +115,20 @@ public class PropFileLoaderSamplePrinterTest {
 				PropFileLoaderSamplePrinterTest.Config.class.getCanonicalName() +
 						".MY_PROP2 = La la la",
 				lines[8]);
-		
+
 		//Print group closing (should be empty line)
 		out.reset();
 		printer.printPropertyGroupEnd(config, out, groupProxy1);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(1, lines.length);
 		assertEquals("", lines[0]);
-		
+
 		//Print file closing (should be empty line)
 		out.reset();
 		printer.printSampleEnd(config, out);
-		
+
 		//System.out.println(out.getTextAsString());
 		lines = out.getTextAsLines();
 		assertEquals(1, lines.length);
@@ -183,5 +183,5 @@ public class PropFileLoaderSamplePrinterTest {
 	@Test
 	public void testGetSampleFileExtension() {
 	}
-	
+
 }

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/main/java/com/dep1/EarthMapMaker.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/main/java/com/dep1/EarthMapMaker.java
@@ -4,7 +4,7 @@ import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.property.*;
 
 /**
- * 
+ *
  * @author eeverman
  */
 @GroupInfo(name="Configuration for Earth map generation", desc="Bounds define max map extents")
@@ -14,15 +14,15 @@ public class EarthMapMaker {
 	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").mustBeNonNull().build();
 	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").mustBeNonNull().build();
 	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").mustBeNonNull().build();
-	
+
 	//System logging configuration for this class
 	public static final BolProp BROADCAST_LOG_EVENTS = BolProp.builder().aliasIn("EMM.Broadcast").defaultValue(true)
 			.desc("If true, logs events are sent to the central logging server").build();
 	public static final StrProp LOG_SERVER = StrProp.builder().aliasIn("EMM.LogServer")
-			.mustStartWith("http://").mustEndWith("/")
+			.startsWith("http://").endsWith("/")
 			.defaultValue("http://prod.mybiz.com.logger/EarthMapMaker/")
-			.desc("The logging server to send events to").build();	
-	
+			.desc("The logging server to send events to").build();
+
 	public String makeMap() {
 		return "Make a map here...";
 	}
@@ -54,5 +54,5 @@ public class EarthMapMaker {
 	public String getLogServerUrl() {
 		return LOG_SERVER.getValue();
 	}
-	
+
 }

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/main/java/com/dep2/MarsMapMaker.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/main/java/com/dep2/MarsMapMaker.java
@@ -4,7 +4,7 @@ import org.yarnandtail.andhow.*;
 import org.yarnandtail.andhow.property.*;
 
 /**
- * 
+ *
  * @author eeverman
  */
 @GroupInfo(name="Configuration for Mars map generation", desc="Bounds define max map extents")
@@ -14,15 +14,15 @@ public class MarsMapMaker {
 	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").mustBeNonNull().build();
 	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").mustBeNonNull().build();
 	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").mustBeNonNull().build();
-	
+
 	//System logging configuration for this class
 	public static final BolProp BROADCAST_LOG_EVENTS = BolProp.builder().aliasIn("MMM.Broadcast").defaultValue(true)
 			.desc("If true, logs events are sent to the central logging server").build();
 	public static final StrProp LOG_SERVER = StrProp.builder().aliasIn("MMM.LogServer")
-			.mustStartWith("http://").mustEndWith("/")
+			.startsWith("http://").endsWith("/")
 			.defaultValue("http://prod.mybiz.com.logger/MarsMapMaker/")
-			.desc("The logging server to send events to").build();	
-	
+			.desc("The logging server to send events to").build();
+
 	public String makeMap() {
 		return "Make a map here...";
 	}
@@ -46,7 +46,7 @@ public class MarsMapMaker {
 	public int getSouthBound() {
 		return SOUTH_BOUND.getValue();
 	}
-	
+
 	public boolean isLogBroadcastEnabled() {
 		return BROADCAST_LOG_EVENTS.getValue();
 	}
@@ -54,5 +54,5 @@ public class MarsMapMaker {
 	public String getLogServerUrl() {
 		return LOG_SERVER.getValue();
 	}
-	
+
 }

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/main/java/org/dataprocess/ExternalServiceConnector.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/main/java/org/dataprocess/ExternalServiceConnector.java
@@ -6,47 +6,47 @@ import org.yarnandtail.andhow.property.*;
 /**
  * This is an example minimal application configuration.
  * IT DOES NOT WORK ON INITIAL STARTUP - READ ON...
- * 
+ *
  * This example will blowup when this class is first run.  In the console out,
  * there will be a complete example properties file.  Paste this output
  * (beginning and ending with ###### lines) into a properties file named
  * 'andhow.properties' in the project resources.
- * 
+ *
  * Fill in some sample properties run again - note the problem reporting in the
  * console when requirements and validations are violated.
- * 
+ *
  * As an example of a fully functioning properties file, there is an example one
  * named 'renamed_me_to_andhow.properties'
- * 
+ *
  * @author eeverman
  */
 public class ExternalServiceConnector {
-	
 
-	
+
+
 	public String fetchData() {
 		return "Got some data...";
 	}
-	
+
 	public String getConnectionUrl() {
 		return ConnectionConfig.SERVICE_URL.getValue();
 	}
-	
+
 	public int getConnectionTimeout() {
 		return ConnectionConfig.TIMEOUT.getValue();
 	}
-	
-	
+
+
 	//
 	// Here are two configuration groups that are added to AndHow, above.
 	// Normally these would be in separate files, or even better, in files
-	// within the modules they configure.  
+	// within the modules they configure.
 
-	
+
 	@GroupInfo(name="Connection configuration to some external service", desc="Configures communication to the USGS Aquarius service")
 	public interface ConnectionConfig {
-		StrProp SERVICE_URL = StrProp.builder().mustEndWith("/").mustBeNonNull().build();
+		StrProp SERVICE_URL = StrProp.builder().endsWith("/").mustBeNonNull().build();
 		IntProp TIMEOUT = IntProp.builder().defaultValue(50).desc("Timeout in seconds") .build();
 	}
-	
+
 }

--- a/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
@@ -13,7 +13,7 @@ public class Calculator {
 
 	//The AndHow configuration Property to select between two modes (doesn't have to be public)
 	public static final StrProp MODE = StrProp.builder()
-			.mustBeNonNull().mustEqual("DOUBLE", "FLOAT").build();
+			.mustBeNonNull().oneOf("DOUBLE", "FLOAT").build();
 
 	/**
 	 * Do the calculation, but choose which implementation to use based on CALC_MODE

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/AppInitiation.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/AppInitiation.java
@@ -5,7 +5,7 @@ import org.yarnandtail.andhow.property.StrProp;
 
 public class AppInitiation implements AndHowInit {
 
-	public static final StrProp ANDHOW_CLASSPATH_FILE = StrProp.builder().mustStartWith("/")
+	public static final StrProp ANDHOW_CLASSPATH_FILE = StrProp.builder().startsWith("/")
 			.aliasIn("AH_CLASSPATH") /* Make this easier to config by adding an alias */
 			.defaultValue("/checker.default.properties")
 			.description("Path to a file on the classpath.  Classpaths must start w/ a slash.").build();

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
@@ -17,11 +17,11 @@ public class Checker {
 	// - Its a best practice to group AndHow Properties into an interface.
 	interface Config {
 		StrProp PROTOCOL = StrProp.builder().mustBeNonNull().
-				mustEqual("http", "https").build();
+				oneOf("http", "https").build();
 		StrProp SERVER = StrProp.builder().mustBeNonNull().build();
 		IntProp PORT = IntProp.builder().mustBeNonNull().
 				mustBeGreaterThanOrEqualTo(80).mustBeLessThanOrEqualTo(8888).build();
-		StrProp PATH = StrProp.builder().mustStartWith("/").build();
+		StrProp PATH = StrProp.builder().startsWith("/").build();
 	}
 
 	/**

--- a/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
@@ -24,13 +24,13 @@ public class HibernateInit {
 		StrProp DRIVER = StrProp.builder().aliasInAndOut("hibernate.connection.driver_class")
 				.mustBeNonNull().build();
 		StrProp CONN_URL = StrProp.builder().aliasInAndOut("hibernate.connection.url")
-				.mustBeNonNull().mustStartWith("jdbc:").build();
+				.mustBeNonNull().startsWith("jdbc:").build();
 		StrProp USER = StrProp.builder().aliasInAndOut("hibernate.connection.username")
 				.mustBeNonNull().build();
 		StrProp PWD = StrProp.builder().aliasInAndOut("hibernate.connection.password")
 				.mustBeNonNull().build();
 		StrProp ISOLATION = StrProp.builder().aliasInAndOut("hibernate.connection.isolation")
-				.mustEqual("REPEATABLE_READ", "TRANSACTION_REPEATABLE_READ")
+				.oneOf("REPEATABLE_READ", "TRANSACTION_REPEATABLE_READ")
 				.defaultValue("REPEATABLE_READ").build();
 		IntProp INIT_POOL_SIZE = IntProp.builder().aliasInAndOut("hibernate.connection.initial_pool_size")
 				.defaultValue(1).mustBeLessThan(20).build();


### PR DESCRIPTION
Fixes #587 

### All Submissions:

Shorted Property builder:
    * Update StrProp.StrBuilder methods to the new names.
    * Mark old methods as deprecated, delegate to new methods.
    * Add javadoc for deprecated methods with references to new methods.
    * Update all usages to the new method names.

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
