### PR TITLE
Shorted Property builder methods for numeric Properties

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/BigDecProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/BigDecProp.java
@@ -65,13 +65,29 @@ public class BigDecProp extends PropertyBase<BigDecimal> {
         }
 
         /**
+         * @deprecated Use {@code BigDecBuilder.greaterThan()}
+         */
+        @Deprecated
+        public BigDecBuilder mustBeGreaterThan(BigDecimal reference) {
+            return this.greaterThan(reference);
+        }
+
+        /**
          * The property must be greater than the reference
          * @param reference value the property must be greater than
          * @return the builder instance
          */
-        public BigDecBuilder mustBeGreaterThan(BigDecimal reference) {
+        public BigDecBuilder greaterThan(BigDecimal reference) {
             validation(new BigDecValidator.GreaterThan(reference));
             return instance;
+        }
+
+        /**
+         * @deprecated Use {@code BigDecBuilder.greaterThanOrEqualTo()}
+         */
+        @Deprecated
+        public BigDecBuilder mustBeGreaterThanOrEqualTo(BigDecimal reference) {
+            return this.greaterThanOrEqualTo(reference);
         }
 
         /**
@@ -79,9 +95,17 @@ public class BigDecProp extends PropertyBase<BigDecimal> {
          * @param reference value the property must be greater than or equal to
          * @return the builder instance
          */
-        public BigDecBuilder mustBeGreaterThanOrEqualTo(BigDecimal reference) {
+        public BigDecBuilder greaterThanOrEqualTo(BigDecimal reference) {
             validation(new BigDecValidator.GreaterThanOrEqualTo(reference));
             return instance;
+        }
+
+        /**
+         * @deprecated Use {@code BigDecBuilder.lessThan()}
+         */
+        @Deprecated
+        public BigDecBuilder mustBeLessThan(BigDecimal reference) {
+            return this.lessThan(reference);
         }
 
         /**
@@ -89,9 +113,17 @@ public class BigDecProp extends PropertyBase<BigDecimal> {
          * @param reference value the property must be less than
          * @return the builder instance
          */
-        public BigDecBuilder mustBeLessThan(BigDecimal reference) {
+        public BigDecBuilder lessThan(BigDecimal reference) {
             validation(new BigDecValidator.LessThan(reference));
             return instance;
+        }
+
+        /**
+         * @deprecated Use {@code BigDecBuilder.lessThanOrEqualTo()}
+         */
+        @Deprecated
+        public BigDecBuilder mustBeLessThanOrEqualTo(BigDecimal reference) {
+            return this.lessThanOrEqualTo(reference);
         }
 
         /**
@@ -99,7 +131,7 @@ public class BigDecProp extends PropertyBase<BigDecimal> {
          * @param reference value the property must be less than or equal to
          * @return the builder instance
          */
-        public BigDecBuilder mustBeLessThanOrEqualTo(BigDecimal reference) {
+        public BigDecBuilder lessThanOrEqualTo(BigDecimal reference) {
             validation(new BigDecValidator.LessThanOrEqualTo(reference));
             return instance;
         }

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/DblProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/DblProp.java
@@ -7,10 +7,10 @@ import org.yarnandtail.andhow.valuetype.DblType;
 
 /**
  * A Property that refers to a Double value.
- * 
+ *
  * All the basic Java types use a three letter abv. to keep declaration lines
  * short, in the form of:  [Type]Prop
- * 
+ *
  * By default this uses the TrimToNullTrimmer, which removes all whitespace from
  * the value and ultimately null if the value is all whitespace.
  *
@@ -28,23 +28,23 @@ import org.yarnandtail.andhow.valuetype.DblType;
  * name.of.my.double.property.MY_PROPERTY_4 = 60.00d
  * name.of.my.double.property.MY_PROPERTY_5 = 4
  * </code>
- * 
+ *
  * @author eeverman
  */
 public class DblProp extends PropertyBase<Double> {
-	
+
 	public DblProp(
 			Double defaultValue, boolean required, String shortDesc, List<Validator<Double>> validators,
 			List<Name> aliases, PropertyType paramType, ValueType<Double> valueType, Trimmer trimmer,
 			String helpText) {
-		
+
 		super(defaultValue, required, shortDesc, validators, aliases, paramType, valueType, trimmer, helpText);
 	}
-	
+
 	public static DblBuilder builder() {
 		return new DblBuilder();
 	}
-	
+
 	public static class DblBuilder extends PropertyBuilderBase<DblBuilder, DblProp, Double> {
 
 		public DblBuilder() {
@@ -60,23 +60,43 @@ public class DblProp extends PropertyBase<Double> {
 				_aliases, PropertyType.SINGLE_NAME_VALUE, _valueType, _trimmer, _helpText);
 
 		}
-		
+
+		@Deprecated
 		public DblBuilder mustBeGreaterThan(double reference) {
+			return this.greaterThan(reference);
+		}
+
+		public DblBuilder greaterThan(double reference) {
 			validation(new DblValidator.GreaterThan(reference));
 			return instance;
 		}
-		
+
+		@Deprecated
 		public DblBuilder mustBeGreaterThanOrEqualTo(double reference) {
+			return this.greaterThanOrEqualTo(reference);
+		}
+
+		public DblBuilder greaterThanOrEqualTo(double reference) {
 			validation(new DblValidator.GreaterThanOrEqualTo(reference));
 			return instance;
 		}
-		
+
+		@Deprecated
 		public DblBuilder mustBeLessThan(double reference) {
+			return this.lessThan(reference);
+		}
+
+		public DblBuilder lessThan(double reference) {
 			validation(new DblValidator.LessThan(reference));
 			return instance;
 		}
-		
+
+		@Deprecated
 		public DblBuilder mustBeLessThanOrEqualTo(double reference) {
+			return this.lessThanOrEqualTo(reference);
+		}
+
+		public DblBuilder lessThanOrEqualTo(double reference) {
 			validation(new DblValidator.LessThanOrEqualTo(reference));
 			return instance;
 		}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/DblProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/DblProp.java
@@ -61,6 +61,9 @@ public class DblProp extends PropertyBase<Double> {
 
 		}
 
+		/**
+		 * @deprecated Use {@code DblBuilder.greaterThan()}
+		 */
 		@Deprecated
 		public DblBuilder mustBeGreaterThan(double reference) {
 			return this.greaterThan(reference);
@@ -71,6 +74,9 @@ public class DblProp extends PropertyBase<Double> {
 			return instance;
 		}
 
+		/**
+		 * @deprecated Use {@code DblBuilder.greaterThanOrEqualTo()}
+		 */
 		@Deprecated
 		public DblBuilder mustBeGreaterThanOrEqualTo(double reference) {
 			return this.greaterThanOrEqualTo(reference);
@@ -81,6 +87,9 @@ public class DblProp extends PropertyBase<Double> {
 			return instance;
 		}
 
+		/**
+		 * @deprecated Use {@code DblBuilder.lessThan()}
+		 */
 		@Deprecated
 		public DblBuilder mustBeLessThan(double reference) {
 			return this.lessThan(reference);
@@ -91,6 +100,9 @@ public class DblProp extends PropertyBase<Double> {
 			return instance;
 		}
 
+		/**
+		 * @deprecated Use {@code DblBuilder.lessThanOrEqualTo()}
+		 */
 		@Deprecated
 		public DblBuilder mustBeLessThanOrEqualTo(double reference) {
 			return this.lessThanOrEqualTo(reference);

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/IntProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/IntProp.java
@@ -7,29 +7,29 @@ import org.yarnandtail.andhow.valuetype.IntType;
 
 /**
  * A Property that refers to an Integer value.
- * 
+ *
  * All the basic Java types use a three letter abv. to keep declaration lines
  * short, in the form of:  [Type]Prop
- * 
+ *
  * By default this uses the TrimToNullTrimmer, which removes all whitespace from
  * the value and ultimately null if the value is all whitespace.
- * 
+ *
  * @author eeverman
  */
 public class IntProp extends PropertyBase<Integer> {
-	
+
 	public IntProp(
 			Integer defaultValue, boolean required, String shortDesc, List<Validator<Integer>> validators,
 			List<Name> aliases, PropertyType paramType, ValueType<Integer> valueType, Trimmer trimmer,
 			String helpText) {
-		
+
 		super(defaultValue, required, shortDesc, validators, aliases, paramType, valueType, trimmer, helpText);
 	}
-	
+
 	public static IntBuilder builder() {
 		return new IntBuilder();
 	}
-	
+
 	public static class IntBuilder extends PropertyBuilderBase<IntBuilder, IntProp, Integer> {
 
 		public IntBuilder() {
@@ -45,23 +45,55 @@ public class IntProp extends PropertyBase<Integer> {
 				_aliases, PropertyType.SINGLE_NAME_VALUE, _valueType, _trimmer, _helpText);
 
 		}
-		
+
+		/**
+		 * @deprecated Use {@code IntBuilder.greaterThan()}
+		 */
+		@Deprecated
 		public IntBuilder mustBeGreaterThan(int reference) {
+			return this.greaterThan(reference);
+		}
+
+		public IntBuilder greaterThan(int reference) {
 			validation(new IntValidator.GreaterThan(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code IntBuilder.greaterThanOrEqualTo()}
+		 */
+		@Deprecated
 		public IntBuilder mustBeGreaterThanOrEqualTo(int reference) {
+			return this.greaterThanOrEqualTo(reference);
+		}
+
+		public IntBuilder greaterThanOrEqualTo(int reference) {
 			validation(new IntValidator.GreaterThanOrEqualTo(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code IntBuilder.lessThan()}
+		 */
+		@Deprecated
 		public IntBuilder mustBeLessThan(int reference) {
+			return this.lessThan(reference);
+		}
+
+		public IntBuilder lessThan(int reference) {
 			validation(new IntValidator.LessThan(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code IntBuilder.lessThanOrEqualTo()}
+		 */
+		@Deprecated
 		public IntBuilder mustBeLessThanOrEqualTo(int reference) {
+			return this.lessThanOrEqualTo(reference);
+		}
+
+		public IntBuilder lessThanOrEqualTo(int reference) {
 			validation(new IntValidator.LessThanOrEqualTo(reference));
 			return instance;
 		}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/LngProp.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/LngProp.java
@@ -7,10 +7,10 @@ import org.yarnandtail.andhow.valuetype.LngType;
 
 /**
  * A Property that refers to a Long value.
- * 
+ *
  * All the basic Java types use a three letter abv. to keep declaration lines
  * short, in the form of:  [Type]Prop
- * 
+ *
  * By default this uses the TrimToNullTrimmer, which removes all whitespace from
  * the value and ultimately null if the value is all whitespace.
  *
@@ -21,23 +21,23 @@ import org.yarnandtail.andhow.valuetype.LngType;
  * <code>
  * name.of.my.long.property.MY_PROPERTY = 90
  * </code>
- * 
+ *
  * @author eeverman
  */
 public class LngProp extends PropertyBase<Long> {
-	
+
 	public LngProp(
 			Long defaultValue, boolean required, String shortDesc, List<Validator<Long>> validators,
 			List<Name> aliases, PropertyType paramType, ValueType<Long> valueType, Trimmer trimmer,
 			String helpText) {
-		
+
 		super(defaultValue, required, shortDesc, validators, aliases, paramType, valueType, trimmer, helpText);
 	}
-	
+
 	public static LngBuilder builder() {
 		return new LngBuilder();
 	}
-	
+
 	public static class LngBuilder extends PropertyBuilderBase<LngBuilder, LngProp, Long> {
 
 		public LngBuilder() {
@@ -53,23 +53,55 @@ public class LngProp extends PropertyBase<Long> {
 				_aliases, PropertyType.SINGLE_NAME_VALUE, _valueType, _trimmer, _helpText);
 
 		}
-		
+
+		/**
+		 * @deprecated Use {@code LngBuilder.greaterThan()}
+		 */
+		@Deprecated
 		public LngBuilder mustBeGreaterThan(long reference) {
+			return this.greaterThan(reference);
+		}
+
+		public LngBuilder greaterThan(long reference) {
 			validation(new LngValidator.GreaterThan(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code LngBuilder.greaterThanOrEqualTo()}
+		 */
+		@Deprecated
 		public LngBuilder mustBeGreaterThanOrEqualTo(long reference) {
+			return greaterThanOrEqualTo(reference);
+		}
+
+		public LngBuilder greaterThanOrEqualTo(long reference) {
 			validation(new LngValidator.GreaterThanOrEqualTo(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code LngBuilder.lessThan()}
+		 */
+		@Deprecated
 		public LngBuilder mustBeLessThan(long reference) {
+			return this.lessThan(reference);
+		}
+
+		public LngBuilder lessThan(long reference) {
 			validation(new LngValidator.LessThan(reference));
 			return instance;
 		}
-		
+
+		/**
+		 * @deprecated Use {@code LngBuilder.lessThanOrEqualTo()}
+		 */
+		@Deprecated
 		public LngBuilder mustBeLessThanOrEqualTo(long reference) {
+			return this.lessThanOrEqualTo(reference);
+		}
+
+		public LngBuilder lessThanOrEqualTo(long reference) {
 			validation(new LngValidator.LessThanOrEqualTo(reference));
 			return instance;
 		}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class AndHowUsageExampleTest extends AndHowTestBase {
 
 	AndHowConfiguration config;
-	
+
 	@BeforeEach
 	public void setup() {
 
@@ -39,12 +39,12 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 				.addFixedValue(SERVICE_CONFIG.GRAVITY, 9.8)
 				.addFixedValue(SERVICE_CONFIG.PIE, 3.14159);
 	}
-	
+
 	@Test
 	public void testAllValuesAreSet() {
-		
+
 		AndHow.setConfig(config);
-		
+
 		assertEquals("My App", UI_CONFIG.DISPLAY_NAME.getValue());
 		assertEquals("ffffff", UI_CONFIG.BACKGROUP_COLOR.getValue());
 		assertEquals("google.com", SERVICE_CONFIG.REST_ENDPOINT_URL.getValue());
@@ -53,7 +53,7 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 		assertEquals(9.8, SERVICE_CONFIG.GRAVITY.getValue(), .00000001d);
 		assertEquals(3.14159, SERVICE_CONFIG.PIE.getValue(), .00000001d);
 	}
-	
+
 	@Test
 	public void testOptionalValuesAreNotset() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
@@ -64,14 +64,14 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 				.addFixedValue(SERVICE_CONFIG.TIMEOUT_SECONDS, 99);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("My App", UI_CONFIG.DISPLAY_NAME.getValue());
 		assertNull(UI_CONFIG.BACKGROUP_COLOR.getValue());
 		assertEquals("yahoo.com", SERVICE_CONFIG.REST_ENDPOINT_URL.getValue());
 		assertEquals(3, SERVICE_CONFIG.RETRY_COUNT.getValue());
 		assertEquals(99, SERVICE_CONFIG.TIMEOUT_SECONDS.getValue());
 	}
-	
+
 	@Test
 	public void testMissingValuesException() {
 
@@ -163,8 +163,8 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 		StrProp REST_ENDPOINT_URL = StrProp.builder().mustBeNonNull().aliasOut("re_url").build();
 		IntProp RETRY_COUNT = IntProp.builder().defaultValue(3).aliasOut("rc_1").aliasInAndOut("rc_2").build();
 		IntProp TIMEOUT_SECONDS = IntProp.builder().mustBeNonNull().aliasIn("ignoreForExport").aliasOut("ts").build();
-		DblProp GRAVITY = DblProp.builder().mustBeGreaterThan(9.1d).aliasInAndOut("g").mustBeLessThan(10.2d).build();
-		DblProp PIE = DblProp.builder().mustBeGreaterThanOrEqualTo(3.1).mustBeLessThanOrEqualTo(3.2).build();
+		DblProp GRAVITY = DblProp.builder().greaterThan(9.1d).aliasInAndOut("g").lessThan(10.2d).build();
+		DblProp PIE = DblProp.builder().greaterThanOrEqualTo(3.1).lessThanOrEqualTo(3.2).build();
 	}
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -30,7 +30,7 @@ public interface SimpleParams {
 	//Long
 	LngProp LNG_TEN = LngProp.builder().defaultValue(10L).build();
 	LngProp LNG_NULL = LngProp.builder().build();
-	LngProp LNG_LESS_TEN = LngProp.builder().mustBeLessThan(10L).build();
+	LngProp LNG_LESS_TEN = LngProp.builder().lessThan(10L).build();
 
 	//Double
 	DblProp DBL_TEN = DblProp.builder().defaultValue(10d).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -35,7 +35,7 @@ public interface SimpleParams {
 	//Double
 	DblProp DBL_TEN = DblProp.builder().defaultValue(10d).build();
 	DblProp DBL_NULL = DblProp.builder().build();
-	DblProp DBL_LESS_ZERO = DblProp.builder().mustBeLessThan(0).build();
+	DblProp DBL_LESS_ZERO = DblProp.builder().lessThan(0).build();
 
 	//LocalDateTime
 	LocalDateTimeProp LDT_2007_10_01 = LocalDateTimeProp.builder().defaultValue(LocalDateTime.parse("2007-10-01T00:00")).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/SimpleParams.java
@@ -5,38 +5,38 @@ import org.yarnandtail.andhow.property.*;
 
 /**
  * Test set of params w/ one of each type.
- * 
+ *
  * Naming is [type]_[default value]
- * 
+ *
  * @author eeverman
  */
 public interface SimpleParams {
-	
+
 	//Strings
 	StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
 	StrProp STR_NULL = StrProp.builder().aliasInAndOut("String_Null").build();
 	StrProp STR_END_XXX = StrProp.builder().mustEndWith("XXX").build();
-	
+
 	//Flags
 	FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).build();
 	FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).build();
 	FlagProp FLAG_NULL = FlagProp.builder().build();
-	
+
 	//Integers
 	IntProp INT_TEN = IntProp.builder().defaultValue(10).build();
 	IntProp INT_NULL = IntProp.builder().build();
-	IntProp INT_BIG_TEN = IntProp.builder().mustBeGreaterThan(10).build();
-	
+	IntProp INT_BIG_TEN = IntProp.builder().greaterThan(10).build();
+
 	//Long
 	LngProp LNG_TEN = LngProp.builder().defaultValue(10L).build();
 	LngProp LNG_NULL = LngProp.builder().build();
 	LngProp LNG_LESS_TEN = LngProp.builder().mustBeLessThan(10L).build();
-	
+
 	//Double
 	DblProp DBL_TEN = DblProp.builder().defaultValue(10d).build();
 	DblProp DBL_NULL = DblProp.builder().build();
 	DblProp DBL_LESS_ZERO = DblProp.builder().mustBeLessThan(0).build();
-	
+
 	//LocalDateTime
 	LocalDateTimeProp LDT_2007_10_01 = LocalDateTimeProp.builder().defaultValue(LocalDateTime.parse("2007-10-01T00:00")).build();
 	LocalDateTimeProp LDT_NULL = LocalDateTimeProp.builder().build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
@@ -27,7 +27,7 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 	private static final String GROUP_PATH = "org.yarnandtail.andhow.StdConfigSimulatedAppTest.SampleRestClientGroup";
 	private static final String CLASSPATH_BEGINNING = "/org/yarnandtail/andhow/StdConfigSimulatedAppTest.";
 
-	
+
 	@Test
 	public void testAllValuesAreSetViaCmdLineArgAndPropFile() {
 
@@ -35,15 +35,15 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		String[] cmdLineArgs = new String[] {
 			GROUP_PATH + ".classpath_prop_file" + KVP_DELIMITER + CLASSPATH_BEGINNING + "all.props.speced.properties"
 		};
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SampleRestClientGroup.class)
 				.setCmdLineArgs(cmdLineArgs)
 				.setClasspathPropFilePath(SampleRestClientGroup.CLASSPATH_PROP_FILE)
 				.classpathPropertiesRequired();
-		
+
 		AndHow.setConfig(config);
-		
+
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.all.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
 		assertAllPointsSpecedValues("testAllValuesAreSetViaCmdLineArgAndPropFile");
@@ -176,14 +176,14 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		assertFalse(SampleRestClientGroup.REQUEST_META_DATA.getValue(), failDesc);
 		assertTrue(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue(), failDesc);
 	}
-	
+
 	@Test
 	public void testMinimumPropsAreSetViaCmdLineArgAndPropFile() {
 
 		String[] cmdLineArgs = new String[] {
 				GROUP_PATH + ".CLASSPATH_PROP_FILE" + KVP_DELIMITER + CLASSPATH_BEGINNING + "minimum.props.speced.properties"
-		};		
-				
+		};
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SampleRestClientGroup.class)
 				.setCmdLineArgs(cmdLineArgs)
@@ -191,7 +191,7 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 				.classpathPropertiesRequired();
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("/org/yarnandtail/andhow/StdConfigSimulatedAppTest.minimum.props.speced.properties",
 				SampleRestClientGroup.CLASSPATH_PROP_FILE.getValue());
 		assertEquals("aquarius.usgs.gov", SampleRestClientGroup.REST_HOST.getValue());
@@ -203,10 +203,10 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		assertFalse(SampleRestClientGroup.REQUEST_SUMMARY_DATA.getValue());	//a default
 
 	}
-	
+
 	@Test
 	public void testInvalidValuesViaCmdLineArgAndPropFile() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		jndi.activate();
 
@@ -250,7 +250,7 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 		StrProp CLASSPATH_PROP_FILE = StrProp.builder().desc("Classpath location of a properties file w/ props").build();
 		StrProp APP_NAME = StrProp.builder().aliasIn("app.name").aliasIn("app_name").build();
 		StrProp REST_HOST = StrProp.builder().mustMatchRegex(".*\\.usgs\\.gov") .mustBeNonNull().build();
-		IntProp REST_PORT = IntProp.builder().mustBeNonNull().mustBeGreaterThanOrEqualTo(80).mustBeLessThan(10000).build();
+		IntProp REST_PORT = IntProp.builder().mustBeNonNull().greaterThanOrEqualTo(80).lessThan(10000).build();
 		StrProp REST_SERVICE_NAME = StrProp.builder().defaultValue("query/").mustEndWith("/").build();
 		StrProp AUTH_KEY = StrProp.builder().mustBeNonNull().build();
 		IntProp RETRY_COUNT = IntProp.builder().defaultValue(2).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/std/StdJndiLoaderTest.java
@@ -21,31 +21,31 @@ import org.yarnandtail.andhow.util.NameUtil;
  * @author ericeverman
  */
 public class StdJndiLoaderTest extends AndHowTestBase {
-	
+
 	public interface ValidParams {
 		//Strings
 		StrProp STR_XXX = StrProp.builder().mustEndWith("XXX").build();
-		IntProp INT_TEN = IntProp.builder().mustBeGreaterThan(10).build();
+		IntProp INT_TEN = IntProp.builder().greaterThan(10).build();
 
 	}
-	
+
 	@Test
 	public void testSplit() {
 		StdJndiLoader loader = new StdJndiLoader();
-		
+
 		//This is the default
 		List<String> result = loader.split("java:comp/env/, \"\",");
 		assertEquals(2, result.size());
 		assertEquals("java:comp/env/", result.get(0));
 		assertEquals("", result.get(1));
-		
+
 		//Should leave prefix completely unmodified (not add a trailing slash)
 		result = loader.split(" comp/env , , \"_\",x/y/z");
 		assertEquals(3, result.size());
 		assertEquals("comp/env", result.get(0));
 		assertEquals("_", result.get(1));
 		assertEquals("x/y/z", result.get(2));
-		
+
 		//Should be able to indicate an empty string and whitespace w/ double quotes.
 		result = loader.split(" comp/env , \"\" , \" \"");
 		assertEquals(3, result.size());
@@ -57,39 +57,39 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 
 	@Test
 	public void testHappyPathFromStringsCompEnvAsURIs() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:comp/env/" + 
+
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null");
-		jndi.bind("" + 
+		jndi.bind("" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE)), "false");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), "true");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL)), "TRUE");
-		jndi.bind("" + 
+		jndi.bind("" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), "-999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), "999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), "-999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL)), "999");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01)), "2007-11-02T00:00");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL)), "2007-11-02T00:00");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -102,10 +102,10 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsCompEnvAsClasspath() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test");
@@ -120,12 +120,12 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01), "2007-11-02T00:00");
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL), "2007-11-02T00:00");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -140,31 +140,31 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsFromAddedNonStdPaths() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:/test/" + 
+
+		jndi.bind("java:/test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
 		jndi.bind("java:/test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), "false");
-		jndi.bind("java:test/" + 
+		jndi.bind("java:test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), "true");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
 		jndi.bind("java:myapp/root/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), "-999");
 		//This should still work
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), "999");
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/,    java:test/  ,   java:myapp/root/")
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -173,17 +173,17 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-999, SimpleParams.INT_TEN.getValue());
 		assertEquals(999, SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromStringsFromAddedAndReplacementNonStdPaths() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:zip/" + 
+
+		jndi.bind("java:zip/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
 		jndi.bind("java:xy/z/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL), "not_null");
-		jndi.bind("java:/test/" + 
+		jndi.bind("java:/test/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE)), "false");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE), "true");
 		jndi.bind("java:test/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), "TRUE");
@@ -191,15 +191,15 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		//This should NOT work
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), "999");
 		jndi.activate();
-		
-		
+
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addFixedValue(StdJndiLoader.CONFIG.STANDARD_JNDI_ROOTS, "java:zip/,java:xy/z/")
 				.addFixedValue(StdJndiLoader.CONFIG.ADDED_JNDI_ROOTS, "java:/test/  ,  ,java:test/ , java:myapp/root/")
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals("test", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -208,33 +208,33 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-999, SimpleParams.INT_TEN.getValue());
 		assertNull(SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromObjectsCompEnv() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
-		jndi.bind("java:comp/env/" + 
+
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "test");
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null");
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), Boolean.FALSE);
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE), Boolean.TRUE);
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL)), Boolean.TRUE);
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN)), Integer.valueOf(-999));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL), Integer.valueOf(999));
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN)), Long.valueOf(-999));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_NULL), Long.valueOf(999));
-		jndi.bind("java:comp/env/" + 
+		jndi.bind("java:comp/env/" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_2007_10_01)), LocalDateTime.parse("2007-11-02T00:00"));
 		jndi.bind("java:comp/env/" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LDT_NULL), LocalDateTime.parse("2007-11-02T00:00"));
-		
+
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
@@ -250,33 +250,33 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_2007_10_01.getValue());
 		assertEquals(LocalDateTime.parse("2007-11-02T00:00"), SimpleParams.LDT_NULL.getValue());
 	}
-	
+
 	@Test
 	public void testHappyPathFromObjectsRoot() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		//switching values slightly to make sure we are reading the correct ones
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test2");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_NULL)), "not_null2");
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_TRUE), Boolean.FALSE);
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_FALSE)), Boolean.TRUE);
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.FLAG_NULL), Boolean.TRUE);
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), -9999);
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)),9999);
-		
+
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
 
 		AndHow.setConfig(config);
-		
-		
+
+
 		assertEquals("test2", SimpleParams.STR_BOB.getValue());
 		assertEquals("not_null2", SimpleParams.STR_NULL.getValue());
 		assertEquals(false, SimpleParams.FLAG_TRUE.getValue());
@@ -285,25 +285,25 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(-9999, SimpleParams.INT_TEN.getValue());
 		assertEquals(9999, SimpleParams.INT_NULL.getValue());
 	}
-	
+
 	//
 	//
 	// Non-HappyPath
 	//
-	
+
 	@Test
 	public void testDuplicateValues() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		//switching values slightly to make sure we are reading the correct ones
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB), "test2");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.STR_BOB)), "not_null2");
 
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
@@ -317,20 +317,20 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertEquals(1, lps.size());
 		assertTrue(lps.get(0) instanceof LoaderProblem.DuplicatePropertyLoaderProblem);
 	}
-	
+
 
 	@Test
 	public void testObjectConversionErrors() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), Long.valueOf(-9999));
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), Float.valueOf(22));
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), Integer.valueOf(-9999));
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(SimpleParams.class);
@@ -348,15 +348,15 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertTrue(lps.get(2) instanceof LoaderProblem.ObjectConversionValueProblem);
 		assertEquals(SimpleParams.LNG_TEN, lps.get(2).getBadValueCoord().getProperty());
 	}
-	
+
 	@Test
 	public void testStringConversionErrors() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_TEN), "234.567");
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(SimpleParams.class, SimpleParams.INT_NULL)), "Apple");
 		jndi.bind("java:" + NameUtil.getAndHowName(SimpleParams.class, SimpleParams.LNG_TEN), "234.567");
 		jndi.activate();
@@ -378,19 +378,19 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 		assertTrue(vps.get(2) instanceof LoaderProblem.StringConversionLoaderProblem);
 		assertEquals(SimpleParams.LNG_TEN, vps.get(2).getBadValueCoord().getProperty());
 	}
-	
+
 
 	@Test
 	public void testValidationIsEnforcedWhenExactTypeUsed() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(ValidParams.class, ValidParams.INT_TEN), Integer.parseInt("9"));
-		jndi.bind("java:" + 
+		jndi.bind("java:" +
 				bns.getUriName(NameUtil.getAndHowName(ValidParams.class, ValidParams.STR_XXX)), "YYY");
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(ValidParams.class);
@@ -403,16 +403,16 @@ public class StdJndiLoaderTest extends AndHowTestBase {
 
 		assertEquals(2, vps.size());
 	}
-	
+
 	@Test
 	public void testValidationIsEnforcedWhenConvertsionUsed() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		jndi.bind("java:" + NameUtil.getAndHowName(ValidParams.class, ValidParams.INT_TEN), "9");
 		jndi.activate();
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(ValidParams.class);

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
@@ -20,7 +20,7 @@ public class Checker {
 				mustEqual("http", "https").build();
 		StrProp SERVER = StrProp.builder().mustBeNonNull().build();
 		IntProp PORT = IntProp.builder().mustBeNonNull().
-				mustBeGreaterThanOrEqualTo(80).mustBeLessThanOrEqualTo(8888).build();
+				greaterThanOrEqualTo(80).lessThanOrEqualTo(8888).build();
 		StrProp PATH = StrProp.builder().mustStartWith("/").build();
 	}
 

--- a/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
@@ -33,9 +33,9 @@ public class HibernateInit {
 				.mustEqual("REPEATABLE_READ", "TRANSACTION_REPEATABLE_READ")
 				.defaultValue("REPEATABLE_READ").build();
 		IntProp INIT_POOL_SIZE = IntProp.builder().aliasInAndOut("hibernate.connection.initial_pool_size")
-				.defaultValue(1).mustBeLessThan(20).build();
+				.defaultValue(1).lessThan(20).build();
 		IntProp POOL_SIZE = IntProp.builder().aliasInAndOut("hibernate.connection.pool_size")
-				.defaultValue(20).mustBeLessThan(200).build();
+				.defaultValue(20).lessThan(200).build();
 	}
 
 	@ManualExportNotAllowed


### PR DESCRIPTION
Fixes #608 

### All Submissions:

Shorted Property builder:
* Update numeric builder methods to the new names.
* Mark old methods as deprecated, delegate to new methods.
* Add javadoc for deprecated methods with references to new methods.
* Update all usages to the new method names.

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
