### PR TITLE
Shorten PropertyBuilderBase builder method name

### DIFF
--- a/andhow-core/src/main/java/org/yarnandtail/andhow/Options.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/Options.java
@@ -25,7 +25,7 @@ public interface Options {
 			.desc("Forces configuration samples to be sent to the console for each loader that supports it.")
 			.helpText("On cmdline, this works as a flag and is assumed 'true' just by being present. In other config sources it can be set to 'true'.")
 			.build();
-	StrProp SAMPLES_DIRECTORY = StrProp.builder().defaultValue("java.io.tmpdir/andhow-samples/").mustBeNonNull().endsWith("/")
+	StrProp SAMPLES_DIRECTORY = StrProp.builder().defaultValue("java.io.tmpdir/andhow-samples/").notNull().endsWith("/")
 			.desc("Path to a directory to be used to write sample configuration to. "
 					+ "The special 'java.io.tmpdir' string is recognized as the current Java temp directory.")
 			.helpText("All paths should be specified w/ forward slashes, even on windows systems.")

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdJndiLoader.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/load/std/StdJndiLoader.java
@@ -108,14 +108,14 @@ import org.yarnandtail.andhow.util.TextUtil;
 public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardLoader {
 
 	private boolean failedEnvironmentAProblem = false;
-	
+
 	/**
 	 * There is no reason to use the constructor in production application code
 	 * because AndHow creates a single instance on demand at runtime.
 	 */
 	public StdJndiLoader() {
 	}
-	
+
 	@Override
 	public LoaderValues load(StaticPropertyConfigurationInternal appConfigDef, ValidatedValuesWithContext existingValues) {
 
@@ -123,9 +123,9 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 
 		ArrayList<ValidatedValue> values = new ArrayList();
 		ProblemList<Problem> problems = new ProblemList();
-		
+
 		try {
-			
+
 			InitialContext ctx = new InitialContext();	//Normally doesn't throw exception, even if no JNDI
 
 			ctx.getEnvironment();	//Should throw error if JNDI is unavailable
@@ -149,7 +149,7 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 					}
 				}
 			}
-			
+
 		} catch (NamingException  ex) {
 
 			if (isFailedEnvironmentAProblem()) {
@@ -161,7 +161,7 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 					"The JndiLoader is configured to ignore this.");
 			}
 		}
-		
+
 		return new LoaderValues(this, values, problems);
 	}
 
@@ -187,9 +187,9 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 
 	/**
 	 * Combines the values of STANDARD_JNDI_ROOTS and ADDED_JNDI_ROOTS into one list of jndi root contexts to search.
-	 * 
+	 *
 	 * Expected values might look like:  java:  or java:/comp/env/
-	 * 
+	 *
 	 * @param values The configuration state.
 	 * @return Never null and never non-empty.
 	 */
@@ -199,28 +199,28 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 		//Add the added roots to the search list first, since they are pretty
 		//likely to be the correct ones if someone explicitly added them.
 		//We still check them all anyway, since a duplicate entry would be ambiguous.
-		
+
 		if (values.getValue(CONFIG.ADDED_JNDI_ROOTS) != null) {
 			List<String> addRoots = split(values.getValue(CONFIG.ADDED_JNDI_ROOTS));
 			myJndiRoots.addAll(addRoots);
 		}
-		
+
 		List<String> addRoots = split(values.getValue(CONFIG.STANDARD_JNDI_ROOTS));
 		myJndiRoots.addAll(addRoots);
 
 		return myJndiRoots;
 	}
-	
+
 	/**
 	 * Builds a complete list of complete JNDI names to search for a parameter value.
-	 * 
+	 *
 	 * @param appConfigDef
 	 * @param roots
 	 * @param prop
 	 * @return An ordered list of jndi names, with (hopefully) the most likely names first.
 	 */
 	protected List<String> buildJndiNames(StaticPropertyConfigurationInternal appConfigDef, List<String> roots, Property prop) {
-		
+
 		List<String> propNames = new ArrayList();		// w/o jndi root prefix
 		List<String> propJndiNames = new ArrayList();	// w/ jndi root prefix - return value
 
@@ -247,21 +247,21 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 				propJndiNames.add(root + propName);
 			}
 		}
-		
+
 		return propJndiNames;
 
 	}
 
 	/**
 	 * Spits a comma separate list of JNDI roots into individual root strings.
-	 * 
+	 *
 	 * Use double quotes to indicate and preserve and empty or white space string.
-	 * 
+	 *
 	 * @param rootStr
 	 * @return A list of JNDI root strings
 	 */
 	protected List<String> split(String rootStr) {
-		
+
 		List<String> cleanRoots = new ArrayList();
 
 		if (rootStr != null) {
@@ -294,7 +294,7 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 	public static interface CONFIG {
 
 		StrProp STANDARD_JNDI_ROOTS = StrProp.builder()
-				.defaultValue("java:comp/env/,java:,\"\"").mustBeNonNull()
+				.defaultValue("java:comp/env/,java:,\"\"").notNull()
 				.desc("A comma separated list of standard JNDI root locations to be searched for properties. "
 						+ "Setting this property will replace the standard list, "
 						+ "use ADDED_JNDI_ROOTS to only add to the list. ")
@@ -306,22 +306,22 @@ public class StdJndiLoader extends BaseLoader implements LookupLoader, StandardL
 				.helpText("The final JNDI URIs to be searched will look like this '[root][Property Name]'").build();
 
 	}
-	
+
 	@Override
 	public String getLoaderType() {
 		return "JNDI";
 	}
-	
+
 	@Override
 	public String getLoaderDialect() {
 		return null;
 	}
-	
+
 	@Override
 	public void setFailedEnvironmentAProblem(boolean isAProblem) {
 		failedEnvironmentAProblem = isAProblem;
 	}
-	
+
 	@Override
 	public boolean isFailedEnvironmentAProblem() {
 		return failedEnvironmentAProblem;

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
@@ -88,6 +88,7 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	/**
 	 * @deprecated Use {@code PropertyBuilderBase.notNull()}
 	 */
+	@Deprecated
 	public B mustBeNonNull() {
 		return this.notNull();
 	}

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
@@ -75,8 +75,8 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	 * Assigns a default value for the property.
 	 * 
 	 * The default value must pass all assigned validation rules, including
-	 * being mustBeNonNull, if set.
-	 * 
+	 * being notNull, if set.
+	 *
 	 * @param defaultValue
 	 * @return 
 	 */

--- a/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
+++ b/andhow-core/src/main/java/org/yarnandtail/andhow/property/PropertyBuilderBase.java
@@ -86,18 +86,25 @@ public abstract class PropertyBuilderBase<B extends PropertyBuilderBase, P exten
 	}
 	
 	/**
-	 * If set, the effective value must be non-null to be considered valid.
-	 * 
-	 * The effective value is the explicitly configured value, or if that is null,
-	 * the default value.
-	 * 
-	 * @return 
+	 * @deprecated Use {@code PropertyBuilderBase.notNull()}
 	 */
 	public B mustBeNonNull() {
+		return this.notNull();
+	}
+
+	/**
+	 * If set, the effective value must be non-null to be considered valid.
+	 *
+	 * The effective value is the explicitly configured value, or if that is null,
+	 * the default value.
+	 *
+	 * @return
+	 */
+	public B notNull() {
 		this._nonNull = true;
 		return instance;
 	}
-	
+
 	/**
 	 * Same as description
 	 * 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowTest.java
@@ -41,11 +41,11 @@ public class AndHowTest extends AndHowTestBase {
 	String[] cmdLineArgsWFullClassName = new String[0];
 
 	public static interface RequiredParams {
-		StrProp STR_BOB_R = StrProp.builder().defaultValue("Bob").mustBeNonNull().build();
-		StrProp STR_NULL_R = StrProp.builder().mustBeNonNull().startsWith("XYZ").build();
-		FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).mustBeNonNull().build();
-		FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).mustBeNonNull().build();
-		FlagProp FLAG_NULL = FlagProp.builder().mustBeNonNull().build();
+		StrProp STR_BOB_R = StrProp.builder().defaultValue("Bob").notNull().build();
+		StrProp STR_NULL_R = StrProp.builder().notNull().startsWith("XYZ").build();
+		FlagProp FLAG_FALSE = FlagProp.builder().defaultValue(false).notNull().build();
+		FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).notNull().build();
+		FlagProp FLAG_NULL = FlagProp.builder().notNull().build();
 	}
 
 	@BeforeEach

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHowUsageExampleTest.java
@@ -154,15 +154,15 @@ public class AndHowUsageExampleTest extends AndHowTestBase {
 
 	@ManualExportAllowed(useCanonicalName = EXPORT_CANONICAL_NAME.ALWAYS, useOutAliases = EXPORT_OUT_ALIASES.NEVER)
 	interface UI_CONFIG {
-		StrProp DISPLAY_NAME = StrProp.builder().mustBeNonNull().build();
+		StrProp DISPLAY_NAME = StrProp.builder().notNull().build();
 		StrProp BACKGROUP_COLOR = StrProp.builder().build();
 	}
 
 	@ManualExportAllowed //Defaults to EXPORT_OUT_ALIASES.ALWAYS & EXPORT_CANONICAL_NAME.ONLY_IF_NO_OUT_ALIAS
 	interface SERVICE_CONFIG {
-		StrProp REST_ENDPOINT_URL = StrProp.builder().mustBeNonNull().aliasOut("re_url").build();
+		StrProp REST_ENDPOINT_URL = StrProp.builder().notNull().aliasOut("re_url").build();
 		IntProp RETRY_COUNT = IntProp.builder().defaultValue(3).aliasOut("rc_1").aliasInAndOut("rc_2").build();
-		IntProp TIMEOUT_SECONDS = IntProp.builder().mustBeNonNull().aliasIn("ignoreForExport").aliasOut("ts").build();
+		IntProp TIMEOUT_SECONDS = IntProp.builder().notNull().aliasIn("ignoreForExport").aliasOut("ts").build();
 		DblProp GRAVITY = DblProp.builder().greaterThan(9.1d).aliasInAndOut("g").lessThan(10.2d).build();
 		DblProp PIE = DblProp.builder().greaterThanOrEqualTo(3.1).lessThanOrEqualTo(3.2).build();
 	}

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasInTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author ericeverman
  */
 public class AndHow_AliasInTest extends AndHowTestBase {
-	
+
 	//
 	//Alias names
 	static final String STR_PROP1_IN = "str.Prop.1.In";
@@ -28,43 +28,43 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 	static final String STR_PROP2_IN_ALT2_ALIAS = "StrProp2.InAlt2";
 	static final String INT_PROP1_ALIAS = "IntProp1";
 	static final String INT_PROP1_ALT_IN1_ALIAS = "Int.Prop.1-Alt-In!1";
-	
-	
+
+
 	//
 	//Property values
 	private static final String STR1 = "SOME_FIXED_VALUE_STRING_1";
 	private static final String STR2 = "SOME_FIXED_VALUE_STRING_2";
 	private static final Integer INT1 = 23572374;
 	private static final Integer INT2 = 9237347;
-	
+
 	interface AliasGroup1 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull()
+		StrProp strProp1 = StrProp.builder().notNull()
 				.aliasIn(STR_PROP1_IN).aliasOut(STR_PROP1_OUT_ALIAS).aliasInAndOut(STR_PROP1_IN_AND_OUT_ALIAS).build();
-		
+
 		StrProp strProp2 = StrProp.builder()
 				.aliasIn(STR_PROP2_ALIAS).aliasOut(STR_PROP2_ALIAS).aliasIn(STR_PROP2_IN_ALT1_ALIAS).aliasIn(STR_PROP2_IN_ALT2_ALIAS).build();
 		IntProp intProp1 = IntProp.builder()
 				.aliasIn(INT_PROP1_ALIAS).aliasInAndOut(INT_PROP1_ALIAS).aliasIn(INT_PROP1_ALT_IN1_ALIAS).build();
-		IntProp intProp2 = IntProp.builder().mustBeNonNull().defaultValue(INT2).build();
+		IntProp intProp2 = IntProp.builder().notNull().defaultValue(INT2).build();
 	}
-	
+
 	//Has dup alias for strProp1
 	interface AliasGroup2 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull().aliasIn(STR_PROP1_IN).build();
+		StrProp strProp1 = StrProp.builder().notNull().aliasIn(STR_PROP1_IN).build();
 	}
-	
+
 	//Has dup alias for strProp1
 	interface AliasGroup3 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull().aliasIn(STR_PROP1_IN_AND_OUT_ALIAS).build();
+		StrProp strProp1 = StrProp.builder().notNull().aliasIn(STR_PROP1_IN_AND_OUT_ALIAS).build();
 	}
-	
+
 	//Has dup alias for strProp1, but is all lower case
 	interface AliasGroup4 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull().aliasIn(STR_PROP1_IN.toLowerCase()).build();
+		StrProp strProp1 = StrProp.builder().notNull().aliasIn(STR_PROP1_IN.toLowerCase()).build();
 	}
 
 
-	
+
 	@Test
 	public void testFirstSetOfInAliasesViaCmdLine() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
@@ -74,13 +74,13 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
 	}
-	
+
 	@Test
 	public void testSecondSetOfInAliasesViaCmdLine() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
@@ -90,12 +90,12 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 	}
-	
+
 	@Test
 	public void testThirdSetOfInAliasesViaCmdLine() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
@@ -105,17 +105,17 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 	}
-	
+
 
 
 	@Test
 	public void testInAliasesViaJndiCompEnvClassPath() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 
 		jndi.bind("java:comp/env/" + STR_PROP1_IN, STR1);
@@ -123,22 +123,22 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		jndi.bind("java:comp/env/" + INT_PROP1_ALIAS, INT1.toString());
 
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
 	}
-	
+
 	@Test
 	public void testInAliasesViaJndiRootClassPath() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 
 		jndi.bind("java:" + STR_PROP1_IN_AND_OUT_ALIAS, STR1);
@@ -146,22 +146,22 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		jndi.bind("java:" + INT_PROP1_ALT_IN1_ALIAS, INT1.toString());
 
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
 	}
-	
+
 	@Test
 	public void testInAliasesViaJndiCompEnvUrlNames() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
 
@@ -170,22 +170,22 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		jndi.bind("java:comp/env/" + bns.getUriName(INT_PROP1_ALIAS), INT1.toString());
 
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
 	}
-	
+
 	@Test
 	public void testInAliasesViaJndiRootUrlNames() throws Exception {
-		
+
 		SimpleNamingContextBuilder jndi = getJndi();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
 
@@ -194,25 +194,25 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		jndi.bind("java:" + bns.getUriName(INT_PROP1_ALIAS), INT1.toString());
 
 		jndi.activate();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.setLoaders(new StdJndiLoader())
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
 	}
-	
+
 	//
 	// Degenerate cases
 
 	@Test
 	public void testSingleInDuplicateOfGroup1InAlias() {
-		
+
 
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addCmdLineArg(STR_PROP1_IN, STR1)	//minimal values set to ensure no missing value error
@@ -226,7 +226,7 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
 
 		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
+
 		assertEquals(1, probs.size());
 		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
 		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
@@ -234,7 +234,7 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		assertEquals(AliasGroup2.strProp1, nun.getBadPropertyCoord().getProperty());
 		assertEquals(STR_PROP1_IN, nun.getConflictName());
 	}
-	
+
 
 	@Test
 	public void testSingleInDuplicateOfGroup1InAliasInLowerCase() {
@@ -251,7 +251,7 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
 
 		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
+
 		assertEquals(1, probs.size());
 		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
 		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
@@ -259,7 +259,7 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		assertEquals(AliasGroup4.strProp1, nun.getBadPropertyCoord().getProperty());
 		assertEquals(STR_PROP1_IN.toLowerCase(), nun.getConflictName());
 	}
-	
+
 	@Test
 	public void testSingleInDuplicateOfGroup1InOutAlias() {
 
@@ -275,7 +275,7 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
 
 		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
+
 		assertEquals(1, probs.size());
 		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
 		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
@@ -283,5 +283,5 @@ public class AndHow_AliasInTest extends AndHowTestBase {
 		assertEquals(AliasGroup3.strProp1, nun.getBadPropertyCoord().getProperty());
 		assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
 	}
-	
+
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/AndHow_AliasOutTest.java
@@ -17,7 +17,7 @@ import org.yarnandtail.andhow.property.StrProp;
  * @author ericeverman
  */
 public class AndHow_AliasOutTest extends AndHowTestBase {
-	
+
 	//
 	//Alias names
 	static final String STR_PROP1_IN = "str.Prop.1.In";
@@ -27,64 +27,64 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 	static final String STR_PROP2_OUT_ALIAS = "strProp2-out";
 	static final String INT_PROP1_ALIAS = "IntProp1";
 	static final String INT_PROP1_ALT_IN1_ALIAS = "Int.Prop.1-Alt-In!1";
-	
-	
+
+
 	//
 	//Property values
 	private static final String STR1 = "SOME_FIXED_VALUE_STRING_1";
 	private static final String STR2 = "SOME_FIXED_VALUE_STRING_2";
 	private static final Integer INT1 = 23572374;
 	private static final Integer INT2 = 9237347;
-	
+
 	@GroupExport(
 		exporter=SysPropExporter.class,
 		exportByCanonicalName=EXPORT_CANONICAL_NAME.ONLY_IF_NO_OUT_ALIAS,
 		exportByOutAliases=EXPORT_OUT_ALIASES.ALWAYS
 	)
 	interface AliasGroup1 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull()
+		StrProp strProp1 = StrProp.builder().notNull()
 				.aliasIn(STR_PROP1_IN).aliasOut(STR_PROP1_OUT_ALIAS).aliasInAndOut(STR_PROP1_IN_AND_OUT_ALIAS).build();
 		StrProp strProp2 = StrProp.builder()
 				.aliasIn(STR_PROP2_IN_ALIAS).build();
 		IntProp intProp1 = IntProp.builder()
 				.aliasIn(INT_PROP1_ALIAS).aliasInAndOut(INT_PROP1_ALIAS).aliasIn(INT_PROP1_ALT_IN1_ALIAS).build();
-		IntProp intProp2 = IntProp.builder().mustBeNonNull().defaultValue(INT2).build();
+		IntProp intProp2 = IntProp.builder().notNull().defaultValue(INT2).build();
 	}
-	
+
 
 	//Has dup alias for strProp1
 	interface AliasGroup4 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull().aliasOut(STR_PROP1_IN_AND_OUT_ALIAS).build();
+		StrProp strProp1 = StrProp.builder().notNull().aliasOut(STR_PROP1_IN_AND_OUT_ALIAS).build();
 	}
-	
+
 	interface AliasGroup5 {
 		StrProp strProp1 = StrProp.builder().aliasOut(STR_PROP1_OUT_ALIAS).build();
 		StrProp strProp2 = StrProp.builder().aliasOut(STR_PROP1_OUT_ALIAS).build();	//dup right here in the same group
 	}
-	
+
 	interface AliasGroup6 {
 		StrProp strProp1 = StrProp.builder().aliasOut(STR_PROP1_OUT_ALIAS).build();
 		StrProp strProp2 = StrProp.builder().aliasOut(STR_PROP2_OUT_ALIAS).build();
 	}
-	
+
 	interface AliasGroup7 {
 		StrProp strProp1 = StrProp.builder().aliasOut(STR_PROP1_OUT_ALIAS).build();
 		StrProp strProp2 = StrProp.builder().aliasOut(STR_PROP2_OUT_ALIAS).build();
 	}
 
-	
+
 	@GroupExport(
 		exporter=SysPropExporter.class,
 		exportByCanonicalName=EXPORT_CANONICAL_NAME.ONLY_IF_NO_OUT_ALIAS,
 		exportByOutAliases=EXPORT_OUT_ALIASES.ALWAYS
 	)
 	interface AliasGroup2 {
-		StrProp strProp1 = StrProp.builder().mustBeNonNull().build();
+		StrProp strProp1 = StrProp.builder().notNull().build();
 		StrProp strProp2 = StrProp.builder().build();
 		IntProp intProp1 = IntProp.builder().build();
-		IntProp intProp2 = IntProp.builder().mustBeNonNull().defaultValue(INT2).build();
+		IntProp intProp2 = IntProp.builder().notNull().defaultValue(INT2).build();
 	}
-	
+
 	@Test
 	public void testOutAliasForGroup1() {
 		AndHowConfiguration config = AndHowTestConfig.instance()
@@ -94,41 +94,41 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 				.addOverrideGroup(AliasGroup1.class);
 
 		AndHow.setConfig(config);
-		
+
 		//This just tests the test...
 		assertEquals(STR1, AliasGroup1.strProp1.getValue());
 		assertEquals(STR2, AliasGroup1.strProp2.getValue());
 		assertEquals(INT1, AliasGroup1.intProp1.getValue());
 		assertEquals(INT2, AliasGroup1.intProp2.getValue());	//default should still come thru
-		
+
 		//
 		//And now for something more interesting
-		
+
 		//strProp1
 		assertEquals(STR1, System.getProperty(STR_PROP1_OUT_ALIAS));
 		assertEquals(STR1, System.getProperty(STR_PROP1_IN_AND_OUT_ALIAS));
 		assertNull(System.getProperty(STR_PROP1_IN));
 		assertNull(System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.strProp1)));
-		
+
 		//strProp2
 		assertEquals(STR2, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.strProp2)));
 		assertNull(System.getProperty(STR_PROP2_IN_ALIAS));
-		
+
 		//intProp1
 		assertEquals(INT1.toString(), System.getProperty(INT_PROP1_ALIAS));
 		assertNull(System.getProperty(INT_PROP1_ALT_IN1_ALIAS));
 		assertNull(System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.intProp1)));
-		
+
 		//intProp2
 		assertEquals(INT2.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.intProp2)));
 	}
-	
+
 
 	@Test
 	public void testOutAliasForGroup2() {
-		
+
 		String grp2Name = AliasGroup2.class.getCanonicalName();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addCmdLineArg(grp2Name + ".strProp1", STR1)
 				.addCmdLineArg(grp2Name + ".strProp2", STR2)
@@ -136,22 +136,22 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 				.addOverrideGroup(AliasGroup2.class);
 
 		AndHow.setConfig(config);
-	
+
 
 		//
 		//No aliases - all canon names should be present
-		
+
 		assertEquals(STR1, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.strProp1)));
 		assertEquals(STR2, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.strProp2)));
 		assertEquals(INT1.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.intProp1)));
 		assertEquals(INT2.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.intProp2)));
 	}
-	
+
 	@Test
 	public void testOutAliasForGroup1and2() {
-		
+
 		String grp2Name = AliasGroup2.class.getCanonicalName();
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(AliasGroup1.class)
 				.addOverrideGroup(AliasGroup2.class)
@@ -164,38 +164,38 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 
 		AndHow.setConfig(config);
 		AndHow.instance();
-		
+
 		//
 		// Group 1
-		
+
 		//strProp1
 		assertEquals(STR1, System.getProperty(STR_PROP1_OUT_ALIAS));
 		assertEquals(STR1, System.getProperty(STR_PROP1_IN_AND_OUT_ALIAS));
 		assertNull(System.getProperty(STR_PROP1_IN));
 		assertNull(System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.strProp1)));
-		
+
 		//strProp2
 		assertEquals(STR2, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.strProp2)));
 		assertNull(System.getProperty(STR_PROP2_IN_ALIAS));
-		
+
 		//intProp1
 		assertEquals(INT1.toString(), System.getProperty(INT_PROP1_ALIAS));
 		assertNull(System.getProperty(INT_PROP1_ALT_IN1_ALIAS));
 		assertNull(System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.intProp1)));
-		
+
 		//intProp2
 		assertEquals(INT2.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup1.intProp2)));
-		
-		
+
+
 		//
 		//No aliases for group 2 - all canon names should be present
-		
+
 		assertEquals(STR1, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.strProp1)));
 		assertEquals(STR2, System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.strProp2)));
 		assertEquals(INT1.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.intProp1)));
 		assertEquals(INT2.toString(), System.getProperty(AndHow.instance().getCanonicalName(AliasGroup2.intProp2)));
 	}
-	
+
 
 	@Test
 	public void testSingleOutDuplicateOfGroup1InOutAlias() {
@@ -212,7 +212,7 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
 
 		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
+
 		assertEquals(1, probs.size());
 		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
 		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
@@ -221,7 +221,7 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		assertEquals(AliasGroup4.class, nun.getBadPropertyCoord().getGroup());
 		assertEquals(STR_PROP1_IN_AND_OUT_ALIAS, nun.getConflictName());
 	}
-	
+
 	@Test
 	public void testSingleOutDuplicateWithinASingleGroup() {
 
@@ -233,7 +233,7 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		AppFatalException e = assertThrows(AppFatalException.class, () -> AndHow.instance());
 
 		List<ConstructionProblem> probs = e.getProblems().filter(ConstructionProblem.class);
-			
+
 		assertEquals(1, probs.size());
 		assertTrue(probs.get(0) instanceof ConstructionProblem.NonUniqueNames);
 		ConstructionProblem.NonUniqueNames nun = (ConstructionProblem.NonUniqueNames)probs.get(0);
@@ -242,7 +242,7 @@ public class AndHow_AliasOutTest extends AndHowTestBase {
 		assertEquals(AliasGroup5.class, nun.getBadPropertyCoord().getGroup());
 		assertEquals(STR_PROP1_OUT_ALIAS, nun.getConflictName());
 	}
-	
+
 	@Test
 	public void testTwoOutOutDuplicatesBetweenTwoGroups() {
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/StdConfigSimulatedAppTest.java
@@ -249,10 +249,10 @@ public class StdConfigSimulatedAppTest extends AndHowTestBase {
 	interface SampleRestClientGroup {
 		StrProp CLASSPATH_PROP_FILE = StrProp.builder().desc("Classpath location of a properties file w/ props").build();
 		StrProp APP_NAME = StrProp.builder().aliasIn("app.name").aliasIn("app_name").build();
-		StrProp REST_HOST = StrProp.builder().matches(".*\\.usgs\\.gov") .mustBeNonNull().build();
-		IntProp REST_PORT = IntProp.builder().mustBeNonNull().greaterThanOrEqualTo(80).lessThan(10000).build();
+		StrProp REST_HOST = StrProp.builder().matches(".*\\.usgs\\.gov") .notNull().build();
+		IntProp REST_PORT = IntProp.builder().notNull().greaterThanOrEqualTo(80).lessThan(10000).build();
 		StrProp REST_SERVICE_NAME = StrProp.builder().defaultValue("query/").endsWith("/").build();
-		StrProp AUTH_KEY = StrProp.builder().mustBeNonNull().build();
+		StrProp AUTH_KEY = StrProp.builder().notNull().build();
 		IntProp RETRY_COUNT = IntProp.builder().defaultValue(2).build();
 		FlagProp REQUEST_META_DATA = FlagProp.builder().defaultValue(true).build();
 		FlagProp REQUEST_SUMMARY_DATA = FlagProp.builder().build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderUnitTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderUnitTest.java
@@ -20,16 +20,16 @@ import org.yarnandtail.andhow.util.AndHowUtil;
  * @author eeverman
  */
 public class PropFileOnClasspathLoaderUnitTest {
-	
+
 	private static final String CLASSPATH_BASE = "/org/yarnandtail/andhow/load/PropFileOnClasspathLoaderUnitTest_SimpleParams";
-	
+
 	StaticPropertyConfigurationMutable appDef;
 	ValidatedValuesWithContextMutable appValuesBuilder;
-	
+
 	public static interface TestProps {
-		StrProp CLAZZ_PATH = StrProp.builder().mustBeNonNull().build();
+		StrProp CLAZZ_PATH = StrProp.builder().notNull().build();
 	}
-	
+
 	public interface SimpleParams {
 		//Strings
 		StrProp STR_BOB = StrProp.builder().aliasIn("String_Bob").aliasInAndOut("Stringy.Bob").defaultValue("bob").build();
@@ -40,20 +40,20 @@ public class PropFileOnClasspathLoaderUnitTest {
 		FlagProp FLAG_TRUE = FlagProp.builder().defaultValue(true).build();
 		FlagProp FLAG_NULL = FlagProp.builder().build();
 	}
-	
+
 	@BeforeEach
 	public void init() throws Exception {
-		
+
 		appValuesBuilder = new ValidatedValuesWithContextMutable();
 		CaseInsensitiveNaming bns = new CaseInsensitiveNaming();
-		
+
 		appDef = new StaticPropertyConfigurationMutable(bns);
-		
+
 		GroupProxy simpleProxy = AndHowUtil.buildGroupProxy(SimpleParams.class);
-		
+
 		appDef.addProperty(AndHowUtil.buildGroupProxy(TestProps.class), TestProps.CLAZZ_PATH);
 
-		
+
 		appDef.addProperty(simpleProxy, SimpleParams.STR_BOB);
 		appDef.addProperty(simpleProxy, SimpleParams.STR_NULL);
 		appDef.addProperty(simpleProxy, SimpleParams.FLAG_FALSE);
@@ -61,24 +61,24 @@ public class PropFileOnClasspathLoaderUnitTest {
 		appDef.addProperty(simpleProxy, SimpleParams.FLAG_NULL);
 
 	}
-	
+
 	@Test
 	public void testHappyPath() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "1.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 		assertEquals("kvpBobValue", result.getExplicitValue(SimpleParams.STR_BOB));
 		assertEquals("kvpNullValue", result.getExplicitValue(SimpleParams.STR_NULL));
 		assertEquals(Boolean.FALSE, result.getExplicitValue(SimpleParams.FLAG_TRUE));
@@ -86,48 +86,48 @@ public class PropFileOnClasspathLoaderUnitTest {
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
 	}
 
-	
+
 	@Test
 	public void testDuplicateEntries() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "2.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 		assertEquals("kvpBobValue", result.getExplicitValue(SimpleParams.STR_BOB));
 		assertEquals("3", result.getExplicitValue(SimpleParams.STR_NULL));
 		assertEquals(Boolean.FALSE, result.getExplicitValue(SimpleParams.FLAG_TRUE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
 	}
-	
+
 	@Test
 	public void testEmptyValues() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "3.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 		assertNull(result.getExplicitValue(SimpleParams.STR_BOB));
 		assertEquals("bob", result.getValue(SimpleParams.STR_BOB));
 		assertNull(result.getExplicitValue(SimpleParams.STR_NULL));
@@ -135,24 +135,24 @@ public class PropFileOnClasspathLoaderUnitTest {
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
 	}
-	
+
 	@Test
 	public void testAllWhitespaceValues() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "4.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 		assertNull(result.getExplicitValue(SimpleParams.STR_BOB));
 		assertEquals("bob", result.getValue(SimpleParams.STR_BOB));
 		assertNull(result.getExplicitValue(SimpleParams.STR_NULL));
@@ -160,106 +160,106 @@ public class PropFileOnClasspathLoaderUnitTest {
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_FALSE));
 		assertEquals(Boolean.TRUE, result.getExplicitValue(SimpleParams.FLAG_NULL));
 	}
-	
+
 	@Test
 	public void testQuotedStringValues() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "5.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
-		
+
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 		assertEquals("  two_spaces_&_two_tabs\t\t", result.getExplicitValue(SimpleParams.STR_BOB));
 		assertEquals("  two_spaces_&_two_tabs\t\t", result.getValue(SimpleParams.STR_BOB));
 		assertEquals("", result.getExplicitValue(SimpleParams.STR_NULL));
 		assertEquals("", result.getValue(SimpleParams.STR_NULL));
 	}
-	
+
 	@Test
 	public void testPropFileLoaderWithUnrecognizedPropNames() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, CLASSPATH_BASE + "6.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		//These are the two bad property names in the file
 		List<String> badPropNames = Arrays.asList(new String[] {
 			"org.yarnandtail.andhow.load.PropFileOnClasspathLoaderUnitTest.SimpleParams.XXX",
 			"org.yarnandtail.andhow.load.PropFileOnClasspathLoaderUnitTest.SimpleXXXXXX.STR_BOB"});
-		
+
 		assertEquals(2, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
 			assertTrue(lp instanceof LoaderProblem.UnknownPropertyLoaderProblem);
-			
+
 			LoaderProblem.UnknownPropertyLoaderProblem uplp = (LoaderProblem.UnknownPropertyLoaderProblem)lp;
-			
+
 			//The problem description should contain one of the bad names
 			assertTrue(
 				badPropNames.stream().anyMatch(n -> uplp.getProblemDescription().contains(n)));
 		}
-		
+
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 	}
-	
+
 	@Test
 	public void testPropFileLoaderWithMissingFile() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(1, result.getProblems().size());
 		for (Problem lp : result.getProblems()) {
 			assertTrue(lp instanceof LoaderProblem.SourceNotFoundLoaderProblem);
 		}
-		
+
 		assertEquals(0L, result.getValues().stream().filter(p -> p.hasProblems()).count());
-		
+
 	}
-	
+
 	/**
 	 * The loader itself is OK w/ not having its parameter specified - it just
 	 * ignores.
 	 */
 	@Test
 	public void testPropFileLoaderWithNoClasspathConfigured() {
-		
+
 		ArrayList<ValidatedValue> evl = new ArrayList();
 		//evl.add(new ValidatedValue(TestProps.CLAZZ_PATH, "/org/yarnandtail/andhow/load/XXXXXXX.properties"));
 		LoaderValues existing = new LoaderValues(new KeyValuePairLoader(), evl, new ProblemList<Problem>());
 		appValuesBuilder.addValues(existing);
-		
+
 		PropFileOnClasspathLoader pfl = new PropFileOnClasspathLoader();
 		pfl.setFilePath(TestProps.CLAZZ_PATH);
 		pfl.setMissingFileAProblem(true);
-		
+
 		LoaderValues result = pfl.load(appDef, appValuesBuilder);
-		
+
 		assertEquals(0, result.getProblems().size());
 	}
 

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/BigDecPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/BigDecPropTest.java
@@ -106,7 +106,7 @@ public class BigDecPropTest extends PropertyTestBase {
     }
 
     public interface BigDecGroup {
-        BigDecProp NOT_NULL = BigDecProp.builder().mustBeNonNull().desc(DESCRIPTION).build();
+        BigDecProp NOT_NULL = BigDecProp.builder().notNull().desc(DESCRIPTION).build();
         BigDecProp NULL = BigDecProp.builder().build();
         BigDecProp GREATER_THAN = BigDecProp.builder().mustBeGreaterThan(GREATER_THAN_OR_EQUAL_VALUE).aliasInAndOut("alias").build();
         BigDecProp GREATER_THAN_OR_EQUAL = BigDecProp.builder().mustBeGreaterThanOrEqualTo(GREATER_THAN_OR_EQUAL_VALUE).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/BolPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/BolPropTest.java
@@ -9,9 +9,9 @@ import org.yarnandtail.andhow.internal.RequirementProblem;
 
 /**
  * Tests StrProp instances as they would be used in an app.
- * 
+ *
  * Focuses on builder functionality, validation and metadata.
- * 
+ *
  * @author ericeverman
  */
 public class BolPropTest extends PropertyTestBase {
@@ -19,32 +19,32 @@ public class BolPropTest extends PropertyTestBase {
 	@Test
 	public void happyPathTest() {
 		this.buildConfig(this, "_happyPath", BolGroup.class);
-		
+
 		assertTrue(BolGroup.ENABLE.getValue());
 		assertTrue(BolGroup.ALIAS_ME.getValue());
 		assertTrue(BolGroup.BIG_SWITCH_TRUE.getValue());
 		assertFalse(BolGroup.BIG_SWITCH_FALSE.getValue());
 		assertNull(BolGroup.BIG_SWITCH_NULL.getValue());
-		
+
 		assertEquals("enable desc", BolGroup.ENABLE.getDescription());
 		assertTrue(BolGroup.ENABLE.isNonNullRequired());
 		assertEquals("iAmAliased", BolGroup.ALIAS_ME.getRequestedAliases().get(0).getActualName());
 	}
-	
+
 	@Test
 	public void happyPathSetFalseTest() {
 		this.buildConfig(this, "_happyPathSetFalse", BolGroup.class);
-		
+
 		assertFalse(BolGroup.ENABLE.getValue());
 		assertFalse(BolGroup.ALIAS_ME.getValue());
 		assertFalse(BolGroup.BIG_SWITCH_TRUE.getValue());
 		assertFalse(BolGroup.BIG_SWITCH_FALSE.getValue());
 		assertFalse(BolGroup.BIG_SWITCH_NULL.getValue());
 	}
-	
+
 	@Test
 	public void failDueToNotSettingRequiredNonNullTest() {
-		
+
 		try {
 			this.buildConfig(this, "_enableNotSet", BolGroup.class);
 		} catch (AppFatalException e) {
@@ -53,9 +53,9 @@ public class BolPropTest extends PropertyTestBase {
 			assertTrue(problems.get(0) instanceof RequirementProblem);
 		}
 	}
-	
+
 	public interface BolGroup {
-		BolProp ENABLE = BolProp.builder().mustBeNonNull().desc("enable desc").build();
+		BolProp ENABLE = BolProp.builder().notNull().desc("enable desc").build();
 		BolProp ALIAS_ME = BolProp.builder().aliasInAndOut("iAmAliased").build();
 		BolProp BIG_SWITCH_TRUE = BolProp.builder().defaultValue(true).build();
 		BolProp BIG_SWITCH_FALSE = BolProp.builder().defaultValue(false).build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBaseTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBaseTest.java
@@ -147,7 +147,7 @@ public class PropertyBaseTest extends PropertyTestBase {
 				.aliasIn("Str2In1").aliasIn("Str2In1")	//duplicated
 				.build();
 
-		StrProp STR3 = StrProp.builder().defaultValue("xxx").mustBeNonNull()
+		StrProp STR3 = StrProp.builder().defaultValue("xxx").notNull()
 				.aliasIn("Str3").aliasIn("Str3")	//duplicated
 				.aliasInAndOut("Str3") //duplicated
 				.build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBuilderBaseTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyBuilderBaseTest.java
@@ -87,5 +87,14 @@ public class PropertyBuilderBaseTest {
 			builder.aliasInAndOut(null)
 		);
 	}
-	
+
+	@Test
+	public void setNotNullTest() {
+		TestBuilder builder = new TestBuilder();
+		assertFalse(builder._nonNull);
+
+		builder.mustBeNonNull();
+
+		assertTrue(builder._nonNull);
+	}
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyTestBase.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/PropertyTestBase.java
@@ -9,22 +9,22 @@ import org.yarnandtail.andhow.util.TextUtil;
  * @author eeverman
  */
 public class PropertyTestBase extends AndHowTestBase {
-	
-	
+
+
 	public <T extends AndHowTestBase> String buildPropFilePath(T testClass, String propFileSuffix) {
 		String testPkgName = testClass.getClass().getPackage().getName();
 		String testClsName = testClass.getClass().getSimpleName();
-		
-		return "/" + testPkgName.replace(".", "/") + "/" + testClsName + 
+
+		return "/" + testPkgName.replace(".", "/") + "/" + testClsName +
 				TextUtil.trimToEmpty(propFileSuffix) + ".properties";
 	}
-	
+
 	public <T extends AndHowTestBase> void  buildConfig(T testClass, String propFileSuffix,
 																											Class<?>... group) {
-		
+
 		String propFilePath = buildPropFilePath(testClass, propFileSuffix);
 		List<Class<?>> groups = Arrays.asList(group);
-		
+
 		AndHowConfiguration config = AndHowTestConfig.instance()
 				.addOverrideGroup(TEST_CONFIG.class)
 				.addOverrideGroups(groups)
@@ -35,10 +35,10 @@ public class PropertyTestBase extends AndHowTestBase {
 		AndHow.setConfig(config);
 		AndHow.instance();
 	}
-	
+
 	public static interface TEST_CONFIG {
-		StrProp PROP_FILE = StrProp.builder().mustBeNonNull().build();
+		StrProp PROP_FILE = StrProp.builder().notNull().build();
 	}
-	
+
 
 }

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/property/StrPropTest.java
@@ -58,7 +58,7 @@ public class StrPropTest extends PropertyTestBase {
 
 	public interface ValidationGroup {
 		StrProp USER_NAME = StrProp.builder().aliasInAndOut("name").mustMatchRegex("[a-z]+")
-				.mustBeNonNull().desc("Lowercase Only").build();
+				.notNull().desc("Lowercase Only").build();
 
 		StrProp GMAIL_ANY_CASE = StrProp.builder().mustEndWithIgnoreCase("@gmail.com")
 				.description("Ends w/ @gmail.com").build();

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/JndiLoaderSamplePrinterTest.java
@@ -27,7 +27,7 @@ public class JndiLoaderSamplePrinterTest {
 		IntProp MY_PROP1 = IntProp.builder().build();
 		StrProp MY_PROP2 = StrProp.builder().defaultValue("La la la").desc("mp description")
 				.helpText("Long text on how to use the property").startsWith("La").endsWith("la")
-				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
+				.notNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
 
 	@BeforeEach

--- a/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
+++ b/andhow-core/src/test/java/org/yarnandtail/andhow/sample/PropFileLoaderSamplePrinterTest.java
@@ -28,7 +28,7 @@ public class PropFileLoaderSamplePrinterTest {
 		IntProp MY_PROP1 = IntProp.builder().build();
 		StrProp MY_PROP2 = StrProp.builder().defaultValue("La la la").desc("mp description")
 				.helpText("Long text on how to use the property").startsWith("La").endsWith("la")
-				.mustBeNonNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
+				.notNull().aliasIn("mp2").aliasInAndOut("mp2_alias2").aliasOut("mp2_out").build();
 	}
 
 	@BeforeEach

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/main/java/com/dep1/EarthMapMaker.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep1/src/main/java/com/dep1/EarthMapMaker.java
@@ -9,11 +9,11 @@ import org.yarnandtail.andhow.property.*;
  */
 @GroupInfo(name="Configuration for Earth map generation", desc="Bounds define max map extents")
 public class EarthMapMaker {
-	public static final StrProp MAP_NAME = StrProp.builder().desc("Name displayed at the top of the map").mustBeNonNull().build();
-	private static final IntProp WEST_BOUND = IntProp.builder().defaultValue(-124).desc("West-most edge of map, in deg. longitude").mustBeNonNull().build();
-	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").mustBeNonNull().build();
-	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").mustBeNonNull().build();
-	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").mustBeNonNull().build();
+	public static final StrProp MAP_NAME = StrProp.builder().desc("Name displayed at the top of the map").notNull().build();
+	private static final IntProp WEST_BOUND = IntProp.builder().defaultValue(-124).desc("West-most edge of map, in deg. longitude").notNull().build();
+	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").notNull().build();
+	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").notNull().build();
+	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").notNull().build();
 
 	//System logging configuration for this class
 	public static final BolProp BROADCAST_LOG_EVENTS = BolProp.builder().aliasIn("EMM.Broadcast").defaultValue(true)

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/main/java/com/dep2/MarsMapMaker.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-dep2/src/main/java/com/dep2/MarsMapMaker.java
@@ -9,11 +9,11 @@ import org.yarnandtail.andhow.property.*;
  */
 @GroupInfo(name="Configuration for Mars map generation", desc="Bounds define max map extents")
 public class MarsMapMaker {
-	public static final StrProp MAP_NAME = StrProp.builder().desc("Name displayed at the top of the map").mustBeNonNull().build();
-	private static final IntProp WEST_BOUND = IntProp.builder().defaultValue(-124).desc("West-most edge of map, in deg. longitude").mustBeNonNull().build();
-	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").mustBeNonNull().build();
-	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").mustBeNonNull().build();
-	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").mustBeNonNull().build();
+	public static final StrProp MAP_NAME = StrProp.builder().desc("Name displayed at the top of the map").notNull().build();
+	private static final IntProp WEST_BOUND = IntProp.builder().defaultValue(-124).desc("West-most edge of map, in deg. longitude").notNull().build();
+	private static final IntProp NORTH_BOUND = IntProp.builder().defaultValue(50).desc("North-most edge of map, in deg. latitue").notNull().build();
+	private static final IntProp EAST_BOUND = IntProp.builder().defaultValue(-66).desc("East-most edge of map, in deg. longitude").notNull().build();
+	private static final IntProp SOUTH_BOUND = IntProp.builder().defaultValue(24).desc("South-most edge of map, in deg. latitue").notNull().build();
 
 	//System logging configuration for this class
 	public static final BolProp BROADCAST_LOG_EVENTS = BolProp.builder().aliasIn("MMM.Broadcast").defaultValue(true)

--- a/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/main/java/org/dataprocess/ExternalServiceConnector.java
+++ b/andhow-testing/andhow-simulated-app-tests/andhow-multimodule-dataprocess/andhow-default-behavior-test/src/main/java/org/dataprocess/ExternalServiceConnector.java
@@ -45,7 +45,7 @@ public class ExternalServiceConnector {
 
 	@GroupInfo(name="Connection configuration to some external service", desc="Configures communication to the USGS Aquarius service")
 	public interface ConnectionConfig {
-		StrProp SERVICE_URL = StrProp.builder().endsWith("/").mustBeNonNull().build();
+		StrProp SERVICE_URL = StrProp.builder().endsWith("/").notNull().build();
 		IntProp TIMEOUT = IntProp.builder().defaultValue(50).desc("Timeout in seconds") .build();
 	}
 

--- a/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-1/src/main/java/com/bigcorp/Calculator.java
@@ -13,7 +13,7 @@ public class Calculator {
 
 	//The AndHow configuration Property to select between two modes (doesn't have to be public)
 	public static final StrProp MODE = StrProp.builder()
-			.mustBeNonNull().oneOf("DOUBLE", "FLOAT").build();
+			.notNull().oneOf("DOUBLE", "FLOAT").build();
 
 	/**
 	 * Do the calculation, but choose which implementation to use based on CALC_MODE

--- a/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-2/src/main/java/com/bigcorp/Checker.java
@@ -16,10 +16,10 @@ public class Checker {
 	//All the config Properties for this class
 	// - Its a best practice to group AndHow Properties into an interface.
 	interface Config {
-		StrProp PROTOCOL = StrProp.builder().mustBeNonNull().
+		StrProp PROTOCOL = StrProp.builder().notNull().
 				oneOf("http", "https").build();
-		StrProp SERVER = StrProp.builder().mustBeNonNull().build();
-		IntProp PORT = IntProp.builder().mustBeNonNull().
+		StrProp SERVER = StrProp.builder().notNull().build();
+		IntProp PORT = IntProp.builder().notNull().
 				greaterThanOrEqualTo(80).lessThanOrEqualTo(8888).build();
 		StrProp PATH = StrProp.builder().startsWith("/").build();
 	}

--- a/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
+++ b/andhow-testing/andhow-simulated-app-tests/example-app-3/src/main/java/com/bigcorp/HibernateInit.java
@@ -22,13 +22,13 @@ public class HibernateInit {
 	// - Its a best practice to group AndHow Properties into an interface.
 	private interface Config {
 		StrProp DRIVER = StrProp.builder().aliasInAndOut("hibernate.connection.driver_class")
-				.mustBeNonNull().build();
+				.notNull().build();
 		StrProp CONN_URL = StrProp.builder().aliasInAndOut("hibernate.connection.url")
-				.mustBeNonNull().startsWith("jdbc:").build();
+				.notNull().startsWith("jdbc:").build();
 		StrProp USER = StrProp.builder().aliasInAndOut("hibernate.connection.username")
-				.mustBeNonNull().build();
+				.notNull().build();
 		StrProp PWD = StrProp.builder().aliasInAndOut("hibernate.connection.password")
-				.mustBeNonNull().build();
+				.notNull().build();
 		StrProp ISOLATION = StrProp.builder().aliasInAndOut("hibernate.connection.isolation")
 				.oneOf("REPEATABLE_READ", "TRANSACTION_REPEATABLE_READ")
 				.defaultValue("REPEATABLE_READ").build();


### PR DESCRIPTION
Fixes #609 

### All Submissions:

* Create new method `notNull` in the PropertyBuilderBase.
* Mark old method `mustBeNonNull()` as deprecated and reuse new method.
* All usages in the project updated to the new method.

Have you checked that...
* [x] Your pull request is to the *_main_* branch
* [x] Your code is up to date with the latest code from the *_main_*
* [x] You followed the guidelines in our [Developer Guide](https://sites.google.com/view/andhow/developer)?
* [x] Your code does not decrease test coverage (maybe it improves coverage!!)
* [x] If this is related to an issue, please include a link to the issue with the 'Fixes #XXX' syntax.
